### PR TITLE
fix(build): install java 8 by default in image

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -32,6 +32,8 @@ RUN apt-get update \
         libldap2-dev \
         libsasl2-dev \
         libsasl2-modules \
+        zip \
+        unzip \
         ldap-utils \
     && curl -L https://github.com/treff7es/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-${DOCKERIZE_ARCH}-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv \
     && python -m pip install --upgrade pip wheel setuptools==57.5.0
@@ -60,4 +62,6 @@ RUN chown -R datahub /tmp/datahub
 
 FROM ${APP_ENV}-install as final
 USER datahub
+RUN curl -s "https://get.sdkman.io" | bash
+RUN /bin/bash -c "source /$HOME/.sdkman/bin/sdkman-init.sh; sdk version; sdk install java 8.0.332-zulu"
 CMD dockerize -wait http://$GMS_HOST:$GMS_PORT/health -timeout 240s /start_datahub_actions.sh


### PR DESCRIPTION
To fix https://github.com/datahub-project/datahub/issues/4741

Tested on local
```
aseembansal@Aseems-MacBook-Pro datahub-actions % docker run -it --rm tmp bash                                
datahub@c138716c03e3:/$ java -version
openjdk version "1.8.0_332"
OpenJDK Runtime Environment (Zulu 8.62.0.19-CA-linux_aarch64) (build 1.8.0_332-b09)
OpenJDK 64-Bit Server VM (Zulu 8.62.0.19-CA-linux_aarch64) (build 25.332-b09, mixed mode)

```