### PR TITLE
feat(plugin): update filter transformer to allow filtering by nested JSONs

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
+++ b/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
@@ -72,6 +72,11 @@ class FilterTransformer(Transformer):
         return False
 
     def _matches_dict(self, match_filters: Dict[str, Any], match_with: Any) -> bool:
+        if isinstance(match_with, str):
+            try:
+                match_with = json.loads(match_with)
+            except ValueError:
+                pass
         if not isinstance(match_with, dict):
             return False
         for key, val in match_filters.items():

--- a/docker/config/executor.yaml
+++ b/docker/config/executor.yaml
@@ -21,12 +21,17 @@ source:
     topic_routes:
       mcl: ${METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME:-MetadataChangeLog_Versioned_v1}
       pe: ${PLATFORM_EVENT_TOPIC_NAME:-PlatformEvent_v1}
-
 filter: 
   event_type: "MetadataChangeLogEvent_v1"
-  event: 
+  event:
     entityType: "dataHubExecutionRequest"
     changeType: "UPSERT"
+    aspectName:
+      - "dataHubExecutionRequestInput"
+      - "dataHubExecutionRequestSignal"
+    aspect:
+      value:
+        executorId: "${EXECUTOR_ID:-default}"
 action:
   type: "executor"
   config: 


### PR DESCRIPTION
This PR adds an implicit conversion of nested JSON strings to dicts (if possible), to allow filtering by nested objects/properties e.g. the value field of the GenericAspect of the MetadataChangeLog event. Using this it is possible to define a filter for the corresponding executorId (if the events with the "wrong" executor ids are not filtered the dispatcher would raise an error (see [here](https://github.com/acryldata/datahub-actions/blob/6d0d6d4914f11e85f71a38e6b84662dc70dd83a2/datahub-actions/src/datahub_actions/plugin/action/execution/executor_action.py#L146)).

See also the [executor.yaml](https://github.com/Masterchen09/datahub-actions/blob/ba8667f18d0bbda720dfe18a298b9227a24d2b79/docker/config/executor.yaml#L29-L34) for an example.