### PR TITLE
feat(api): implement from_json method for datahub_actions.event.event_envelope.EventEnvelope

### DIFF
--- a/datahub-actions/src/datahub_actions/action/action.py
+++ b/datahub-actions/src/datahub_actions/action/action.py
@@ -16,7 +16,7 @@ from abc import ABCMeta, abstractmethod
 
 from datahub.ingestion.api.closeable import Closeable
 
-from datahub_actions.event.event import EventEnvelope
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.pipeline.pipeline_context import PipelineContext
 
 

--- a/datahub-actions/src/datahub_actions/event/event.py
+++ b/datahub-actions/src/datahub_actions/event/event.py
@@ -11,13 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
-import logging
-from abc import ABCMeta, abstractmethod
-from dataclasses import dataclass
-from typing import Any, Dict
 
-logger = logging.getLogger(__name__)
+from abc import ABCMeta, abstractmethod
 
 
 class Event(metaclass=ABCMeta):
@@ -37,45 +32,3 @@ class Event(metaclass=ABCMeta):
         """
         Convert the event into its JSON representation.
         """
-
-
-# An object representation of the actual change event.
-@dataclass
-class EventEnvelope:
-    # The type of the event. This corresponds to the shape of the payload.
-    event_type: str
-
-    # The event itself
-    event: Event
-
-    # Arbitrary metadata about the event
-    meta: Dict[str, Any]
-
-    # Convert an enveloped event to JSON representation
-    def as_json(self) -> str:
-        # Be careful about converting meta bag, since anything can be put inside at runtime.
-        meta_json = None
-        try:
-            if self.meta is not None:
-                meta_json = json.dumps(self.meta)
-        except Exception:
-            logger.warn(
-                f"Failed to serialize meta field of EventEnvelope to json {self.meta}. Ignoring it during serialization."
-            )
-        result = f'{{ "event_type": "{self.event_type}", "event": {self.event.as_json()}, "meta": {meta_json if meta_json is not None else "null"} }}'
-        return result
-
-    # Convert a json event envelope back into the object.
-    @classmethod
-    def from_json(cls, json_str: str) -> "EventEnvelope":
-        raise Exception("from_json not yet implemented.")
-        # TODO: Deserialize a json event back to an Enveloped Event.
-        # json_obj = json.loads(json)
-        # event_type = json_obj["event_type"]
-        # event = deserialize_event(event_type, json_obj["event"])
-        # meta = json_obj["meta"] if "meta" in json_obj else {}
-        # return EventEnvelope(
-        #    event_type=event_type,
-        #    event=event,
-        #    meta=meta
-        # )

--- a/datahub-actions/src/datahub_actions/event/event_envelope.py
+++ b/datahub-actions/src/datahub_actions/event/event_envelope.py
@@ -1,0 +1,60 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from datahub_actions.event.event import Event
+from datahub_actions.event.event_registry import event_registry
+
+logger = logging.getLogger(__name__)
+
+
+# An object representation of the actual change event.
+@dataclass
+class EventEnvelope:
+    # The type of the event. This corresponds to the shape of the payload.
+    event_type: str
+
+    # The event itself
+    event: Event
+
+    # Arbitrary metadata about the event
+    meta: Dict[str, Any]
+
+    # Convert an enveloped event to JSON representation
+    def as_json(self) -> str:
+        # Be careful about converting meta bag, since anything can be put inside at runtime.
+        meta_json = None
+        try:
+            if self.meta is not None:
+                meta_json = json.dumps(self.meta)
+        except Exception:
+            logger.warn(
+                f"Failed to serialize meta field of EventEnvelope to json {self.meta}. Ignoring it during serialization."
+            )
+        result = f'{{ "event_type": "{self.event_type}", "event": {self.event.as_json()}, "meta": {meta_json if meta_json is not None else "null"} }}'
+        return result
+
+    # Convert a json event envelope back into the object.
+    @classmethod
+    def from_json(cls, json_str: str) -> "EventEnvelope":
+        json_obj = json.loads(json_str)
+        event_type = json_obj["event_type"]
+        event_class = event_registry.get(event_type)
+        event = event_class.from_json(json.dumps(json_obj["event"]))
+        meta = json_obj["meta"] if "meta" in json_obj else {}
+        return EventEnvelope(event_type=event_type, event=event, meta=meta)

--- a/datahub-actions/src/datahub_actions/event/event_registry.py
+++ b/datahub-actions/src/datahub_actions/event/event_registry.py
@@ -40,7 +40,7 @@ class MetadataChangeLogEvent(MetadataChangeLogClass, Event):
     @classmethod
     def from_json(cls, json_str: str) -> "Event":
         json_obj = json.loads(json_str)
-        return cls.from_obj(json_obj, True)
+        return cls.from_obj(json_obj)
 
     def as_json(self) -> str:
         return json.dumps(self.to_obj())
@@ -60,7 +60,7 @@ class EntityChangeEvent(EntityChangeEventClass, Event):
     @classmethod
     def from_json(cls, json_str: str) -> "EntityChangeEvent":
         json_obj = json.loads(json_str)
-        return cls.from_obj(json_obj, True)
+        return cls.from_obj(json_obj)
 
     def as_json(self) -> str:
         json_obj = self.to_obj()

--- a/datahub-actions/src/datahub_actions/pipeline/pipeline.py
+++ b/datahub-actions/src/datahub_actions/pipeline/pipeline.py
@@ -17,7 +17,7 @@ import os
 from typing import List, Optional
 
 from datahub_actions.action.action import Action
-from datahub_actions.event.event import EventEnvelope
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.pipeline.pipeline_config import FailureMode, PipelineConfig
 from datahub_actions.pipeline.pipeline_stats import PipelineStats
 from datahub_actions.pipeline.pipeline_util import (

--- a/datahub-actions/src/datahub_actions/plugin/action/execution/executor_action.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/execution/executor_action.py
@@ -33,7 +33,7 @@ from datahub.metadata.schema_classes import MetadataChangeLogClass
 from pydantic import BaseModel
 
 from datahub_actions.action.action import Action
-from datahub_actions.event.event import EventEnvelope
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.event.event_registry import METADATA_CHANGE_LOG_EVENT_V1_TYPE
 from datahub_actions.pipeline.pipeline_context import PipelineContext
 

--- a/datahub-actions/src/datahub_actions/plugin/action/hello_world/hello_world.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/hello_world/hello_world.py
@@ -18,7 +18,7 @@ from typing import Optional
 from pydantic import BaseModel
 
 from datahub_actions.action.action import Action
-from datahub_actions.event.event import EventEnvelope
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.pipeline.pipeline_context import PipelineContext
 
 logger = logging.getLogger(__name__)

--- a/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
@@ -34,7 +34,7 @@ from datahub.metadata.schema_classes import (
     MetadataChangeLogClass,
 )
 
-from datahub_actions.event.event import EventEnvelope
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.event.event_registry import (
     ENTITY_CHANGE_EVENT_V1_TYPE,
     METADATA_CHANGE_LOG_EVENT_V1_TYPE,

--- a/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
+++ b/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from datahub.configuration import ConfigModel
 
-from datahub_actions.event.event import EventEnvelope
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.pipeline.pipeline_context import PipelineContext
 from datahub_actions.transform.transformer import Transformer
 

--- a/datahub-actions/src/datahub_actions/source/event_source.py
+++ b/datahub-actions/src/datahub_actions/source/event_source.py
@@ -17,7 +17,7 @@ from typing import Iterable
 
 from datahub.ingestion.api.closeable import Closeable
 
-from datahub_actions.event.event import EventEnvelope
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.pipeline.pipeline_context import PipelineContext
 
 

--- a/datahub-actions/src/datahub_actions/transform/transformer.py
+++ b/datahub-actions/src/datahub_actions/transform/transformer.py
@@ -15,7 +15,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import Optional
 
-from datahub_actions.event.event import EventEnvelope
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.pipeline.pipeline_context import PipelineContext
 
 

--- a/datahub-actions/tests/unit/plugin/transform/filter/test_filter_transformer.py
+++ b/datahub-actions/tests/unit/plugin/transform/filter/test_filter_transformer.py
@@ -17,7 +17,8 @@ from typing import Any
 
 from datahub.metadata.schema_classes import DictWrapper
 
-from datahub_actions.event.event import Event, EventEnvelope
+from datahub_actions.event.event import Event
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.event.event_registry import (
     ENTITY_CHANGE_EVENT_V1_TYPE,
     METADATA_CHANGE_LOG_EVENT_V1_TYPE,

--- a/datahub-actions/tests/unit/test_helpers.py
+++ b/datahub-actions/tests/unit/test_helpers.py
@@ -26,7 +26,8 @@ from datahub.metadata.schema_classes import (
 
 from datahub_actions.action.action import Action
 from datahub_actions.action.action_registry import action_registry
-from datahub_actions.event.event import Event, EventEnvelope
+from datahub_actions.event.event import Event
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.event.event_registry import (
     EntityChangeEvent,
     MetadataChangeLogEvent,


### PR DESCRIPTION
For some local testings I have implemented the from_json method of the EventEnvelope. As the method is using the event registry for getting the event class the EventEnvelope had to be moved from the event.py into a separate file (the event_registry.py imports the event.py, which would then have imported the event_registry.py, which would not have worked 😵).