### PR TITLE
perf(docker): retain root user's build cache in docker image

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
 RUN if [ $(arch) = "x86_64" ]; then \
         mkdir /opt/oracle && \
         cd /opt/oracle && \
-        wget -c https://download.oracle.com/otn_software/linux/instantclient/216000/instantclient-basic-linux.x64-21.6.0.0.0dbru.zip && \
+        wget --no-verbose -c https://download.oracle.com/otn_software/linux/instantclient/216000/instantclient-basic-linux.x64-21.6.0.0.0dbru.zip && \
         unzip instantclient-basic-linux.x64-21.6.0.0.0dbru.zip && \
         rm instantclient-basic-linux.x64-21.6.0.0.0dbru.zip && \
         sh -c "echo /opt/oracle/instantclient_21_6 > /etc/ld.so.conf.d/oracle-instantclient.conf" && \
@@ -51,7 +51,7 @@ RUN if [ $(arch) = "x86_64" ]; then \
     else \
         mkdir /opt/oracle && \
         cd /opt/oracle && \
-        wget -c https://download.oracle.com/otn_software/linux/instantclient/191000/instantclient-basic-linux.arm64-19.10.0.0.0dbru.zip && \
+        wget --no-verbose -c https://download.oracle.com/otn_software/linux/instantclient/191000/instantclient-basic-linux.arm64-19.10.0.0.0dbru.zip && \
         unzip instantclient-basic-linux.arm64-19.10.0.0.0dbru.zip && \
         rm instantclient-basic-linux.arm64-19.10.0.0.0dbru.zip && \
         sh -c "echo /opt/oracle/instantclient_19_10 > /etc/ld.so.conf.d/oracle-instantclient.conf" && \
@@ -60,24 +60,28 @@ RUN if [ $(arch) = "x86_64" ]; then \
 
 FROM base as prod-install
 COPY datahub-actions /actions-src
-RUN mkdir -p /etc/datahub/actions
-RUN mkdir -p /tmp/datahub/logs/actions/
-RUN mkdir -p /tmp/datahub/logs/actions/system
+RUN mkdir -p /etc/datahub/actions && mkdir -p /tmp/datahub/logs/actions/system
 RUN cd /actions-src && \
     pip install "." && \
     pip install '.[executor]'
-    
+
 COPY ./docker/datahub-actions/start.sh /start_datahub_actions.sh
 RUN chmod a+x /start_datahub_actions.sh
 
-# Add other default configurations into this! 
-RUN mkdir -p /etc/datahub/actions/conf
-RUN mkdir -p /etc/datahub/actions/system/conf
+# Add other default configurations into this!
+RUN mkdir -p /etc/datahub/actions/conf && mkdir -p /etc/datahub/actions/system/conf
 COPY ./docker/config/executor.yaml /etc/datahub/actions/system/conf
 
-RUN addgroup --system datahub && adduser --system datahub --ingroup datahub
-RUN chown datahub /etc/datahub
-RUN chown -R datahub /tmp/datahub
+RUN addgroup --system datahub && adduser --system datahub --ingroup datahub \
+    && chown datahub /etc/datahub \
+    && chown -R datahub /tmp/datahub
+
+# By transferring the root user's pip cache directory to the datahub
+# user, we can avoid the need for some redundant dependency downloads.
+RUN mkdir -p /home/datahub/.cache \
+    && mv /root/.cache/pip /home/datahub/.cache/pip \
+    && chown -R datahub /home/datahub/.cache/pip
+
 
 
 FROM ${APP_ENV}-install as final


### PR DESCRIPTION
This PR prevents some extra package downloads from PyPI.

Unfortunately, this yields only a modest perf improvement and is most impactful when the container is running with a slow internet connection, which likely isn't the case.

I ran a small and unscientific performance test of setting up a fresh venv: 
```bash
python -m venv venv
source venv/bin/activate
pip install --upgrade pip wheel setuptools
time pip install acryl-datahub[snowflake]
```

- Current (no root cache preservation): 1m9.474s
- With this PR: 0m58.968s
- When all dependencies are already downloaded to cache: 0m43.000s

As such, it seems much of the time is spent determining cache freshness and installing from cache into the `venv` - longer term, we'll need to keep warm venv's ready for use to maintain responsiveness. 
