### PR TITLE
bump(ae): Bumping acryl-executor to 0.0.3.2 

### DIFF
--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -113,7 +113,7 @@ plugins: Dict[str, Set[str]] = {
     "kafka": kafka_common,
     # Action Plugins
     "executor": {
-        "acryl-executor>=0.0.3.1",
+        "acryl-executor>=0.0.3.2",
     }
     # Transformer Plugins (None yet)
 }


### PR DESCRIPTION
- Bumping acryl-executor to v0.0.3.2 to get debug mode fix. 