### PR TITLE
feat(schema-registry): respect schema_registry_config

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
@@ -88,9 +88,9 @@ class KafkaEventSource(EventSource):
 
     def __init__(self, config: KafkaEventSourceConfig, ctx: PipelineContext):
         self.source_config = config
-        self.schema_registry_client = SchemaRegistryClient(
-            {"url": self.source_config.connection.schema_registry_url}
-        )
+        schema_client_config = config.connection.schema_registry_config.copy()
+        schema_client_config["url"] = self.source_config.connection.schema_registry_url
+        self.schema_registry_client = SchemaRegistryClient(schema_client_config)
         self.consumer: confluent_kafka.Consumer = confluent_kafka.DeserializingConsumer(
             {
                 # Provide a custom group id to subcribe to multiple partitions via separate actions pods.


### PR DESCRIPTION
We use our own ca certs for our kafka schema registry so we need to configure our "ingestion_executor" with the cert path. For example:
```yaml
name: "ingestion_executor" 
source:
  type: "kafka"
  config:
    connection:
      bootstrap: ${KAFKA_BOOTSTRAP_SERVER:-localhost:9092}
      schema_registry_url: ${SCHEMA_REGISTRY_URL:-http://localhost:8081}
      schema_registry_config:
        ssl.ca.location: "/usr/local/share/ca-certificates/mycompany/my-certs.crt"
```
This PR passes these setting to the SchemaRegistryClient
