### PR TITLE
fix(kafka-event-source): add namespace to avoid duplicates error when using multiple pipelines

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
@@ -86,11 +86,13 @@ def kafka_messages_observer(labels: Dict[str, str] = {}) -> Callable:
         name="kafka_offset",
         documentation="Kafka offsets per topic, partition",
         labelnames=["topic", "partition", *labels.keys()],
+        namespace=labels.get('pipeline_name')
     )
     counter = Counter(
         name="kafka_messages_count",
         documentation="Number of kafka messages",
         labelnames=[*labels.keys(), "error"],
+        namespace=labels.get('pipeline_name')
     )
 
     def _observe(message):


### PR DESCRIPTION
Deploying multiple kafka source action pipelines causes the following error to appear:
```
ValueError: Duplicated timeseries in CollectorRegistry: {'kafka_offset'}
```
and 
```
ValueError: Duplicated timeseries in CollectorRegistry: {'kafka_messages_count', 'kafka_messages_count_created', 'kafka_messages_count_total'}
```

The fix adds a namespace to the metrics to avoid name collisions.

_This occured when deploying without enabling metrics_