### PR TITLE
feat: allow specifying https protocol for GMS connection

### DIFF
--- a/docker/actions.env
+++ b/docker/actions.env
@@ -1,6 +1,7 @@
 # deprecated in favour of DATAHUB_* version
 GMS_HOST=datahub-gms
 GMS_PORT=8080
+DATAHUB_GMS_PROTOCOL=http
 DATAHUB_GMS_HOST=datahub-gms
 DATAHUB_GMS_PORT=8080
 KAFKA_BOOTSTRAP_SERVER=broker:29092

--- a/docker/config/executor.yaml
+++ b/docker/config/executor.yaml
@@ -34,9 +34,9 @@ filter:
         executorId: "${EXECUTOR_ID:-default}"
 action:
   type: "executor"
-  config: 
+  config:
     executor_id: "${EXECUTOR_ID:-default}"
 datahub:
-  server: "http://${DATAHUB_GMS_HOST:-localhost}:${DATAHUB_GMS_PORT:-8080}"
+  server: "${DATAHUB_GMS_PROTOCOL:-http}://${DATAHUB_GMS_HOST:-localhost}:${DATAHUB_GMS_PORT:-8080}"
   extra_headers:
     Authorization: "Basic ${DATAHUB_SYSTEM_CLIENT_ID:-__datahub_system}:${DATAHUB_SYSTEM_CLIENT_SECRET:-JohnSnowKnowsNothing}"

--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -43,4 +43,4 @@ FROM ${APP_ENV}-install as final
 USER datahub
 RUN curl -s "https://get.sdkman.io" | bash
 RUN /bin/bash -c "source /$HOME/.sdkman/bin/sdkman-init.sh; sdk version; sdk install java 8.0.332-zulu"
-CMD dockerize -wait http://$DATAHUB_GMS_HOST:$DATAHUB_GMS_PORT/health -timeout 240s /start_datahub_actions.sh
+CMD dockerize -wait $DATAHUB_GMS_PROTOCOL://$DATAHUB_GMS_HOST:$DATAHUB_GMS_PORT/health -timeout 240s /start_datahub_actions.sh

--- a/docs/actions/executor.md
+++ b/docs/actions/executor.md
@@ -59,7 +59,7 @@ action:
   type: "executor"
 # Requires DataHub API configurations to report to DataHub
 datahub:
-  server: "http://${DATAHUB_GMS_HOST:-localhost}:${DATAHUB_GMS_PORT:-8080}"
+  server: "${DATAHUB_GMS_PROTOCOL:-http}://${DATAHUB_GMS_HOST:-localhost}:${DATAHUB_GMS_PORT:-8080}"
   # token: <token> # Must have "Manage Secrets" privilege
 ```
 

--- a/examples/executor.yaml
+++ b/examples/executor.yaml
@@ -15,5 +15,5 @@ filter:
 action:
   type: "executor"
 datahub:
-  server: "http://${DATAHUB_GMS_HOST:-localhost}:${DATAHUB_GMS_PORT:-8080}"
+  server: "${DATAHUB_GMS_PROTOCOL:-http}://${DATAHUB_GMS_HOST:-localhost}:${DATAHUB_GMS_PORT:-8080}"
   # token: <your-access-token # Requires 'Manage Secrets' platform privilege.


### PR DESCRIPTION
This PR adds a new environment variable, `DATAHUB_GMS_PROTOCOL`, which allows you to specify either `http` or `https` for the connection to GMS. It defaults to `http` everywhere `DATAHUB_GMS_HOST` was set/used before, and a brief read of the code doesn't reveal any incompatibilities with this strategy.

One callout is that this is slightly different from the Java apps which use `DATAHUB_GMS_USE_SSL` as their env var, however there wasn't a good way to use a boolean for this use case as it's being parsed by `pyyaml` and there's no way to create an inline conditional.