### PR TITLE
fix: remove credential plaintext logging on init

### DIFF
--- a/datahub-actions/src/datahub_actions/cli/actions.py
+++ b/datahub-actions/src/datahub_actions/cli/actions.py
@@ -36,13 +36,13 @@ pipeline_manager = PipelineManager()
 
 def pipeline_config_to_pipeline(pipeline_config: dict) -> Pipeline:
     logger.debug(
-        f"Attempting to create Actions Pipeline using config {pipeline_config}"
+        f"Attempting to create Actions Pipeline using config {pipeline_config.get('name')}"
     )
     try:
         return Pipeline.create(pipeline_config)
     except Exception as e:
         raise Exception(
-            f"Failed to instantiate Actions Pipeline using config {pipeline_config}"
+            f"Failed to instantiate Actions Pipeline using config {pipeline_config.get('name')}"
         ) from e
 
 

--- a/datahub-actions/src/datahub_actions/cli/actions.py
+++ b/datahub-actions/src/datahub_actions/cli/actions.py
@@ -42,7 +42,7 @@ def pipeline_config_to_pipeline(pipeline_config: dict) -> Pipeline:
         return Pipeline.create(pipeline_config)
     except Exception as e:
         raise Exception(
-            f"Failed to instantiate Actions Pipeline using config {pipeline_config.get('name')}"
+            f"Failed to instantiate Actions Pipeline using config {pipeline_config.get('name')}: {e}"
         ) from e
 
 


### PR DESCRIPTION
The current output will write any credentials in the yaml configs to the logs as plain text, which is a security risk. This PR removes that risk by logging the configuration name to the output on error rather than the full configuration with plaintext secrets.

This affects anyone who uses the metadata system authentication for auth to GMS, and anyone who uses a Kafka cluster that has some sort of username/password auth.