### PR TITLE
feat(action): add metadata_change_sync action to sync two datahub instances

### DIFF
--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -146,6 +146,7 @@ entry_points = {
         "executor = datahub_actions.plugin.action.execution.executor_action:ExecutorAction",
         "slack = datahub_actions.plugin.action.slack.slack:SlackNotificationAction",
         "teams = datahub_actions.plugin.action.teams.teams:TeamsNotificationAction",
+        "metadata_change_sync = datahub_actions.plugin.action.metadata_change_sync.metadata_change_sync:MetadataChangeSyncAction",
     ],
     "datahub_actions.transformer.plugins": [],
     "datahub_actions.source.plugins": [],

--- a/datahub-actions/src/datahub_actions/action/action_registry.py
+++ b/datahub-actions/src/datahub_actions/action/action_registry.py
@@ -16,7 +16,11 @@ from datahub.ingestion.api.registry import PluginRegistry
 
 from datahub_actions.action.action import Action
 from datahub_actions.plugin.action.hello_world.hello_world import HelloWorldAction
+from datahub_actions.plugin.action.metadata_change_sync.metadata_change_sync import (
+    MetadataChangeSyncAction,
+)
 
 action_registry = PluginRegistry[Action]()
 action_registry.register_from_entrypoint("datahub_actions.action.plugins")
 action_registry.register("hello_world", HelloWorldAction)
+action_registry.register("metadata_change_sync", MetadataChangeSyncAction)

--- a/datahub-actions/src/datahub_actions/action/action_registry.py
+++ b/datahub-actions/src/datahub_actions/action/action_registry.py
@@ -16,11 +16,7 @@ from datahub.ingestion.api.registry import PluginRegistry
 
 from datahub_actions.action.action import Action
 from datahub_actions.plugin.action.hello_world.hello_world import HelloWorldAction
-from datahub_actions.plugin.action.metadata_change_sync.metadata_change_sync import (
-    MetadataChangeSyncAction,
-)
 
 action_registry = PluginRegistry[Action]()
 action_registry.register_from_entrypoint("datahub_actions.action.plugins")
 action_registry.register("hello_world", HelloWorldAction)
-action_registry.register("metadata_change_sync", MetadataChangeSyncAction)

--- a/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
@@ -1,0 +1,112 @@
+import json
+import logging
+from typing import Dict, List, Optional, Set, Union, cast
+
+from datahub.emitter.rest_emitter import DatahubRestEmitter
+from datahub.metadata.schema_classes import (
+    MetadataChangeLogClass,
+    MetadataChangeProposalClass,
+)
+from pydantic import BaseModel
+
+from datahub_actions.action.action import Action
+from datahub_actions.event.event_envelope import EventEnvelope
+from datahub_actions.event.event_registry import METADATA_CHANGE_LOG_EVENT_V1_TYPE
+from datahub_actions.pipeline.pipeline_context import PipelineContext
+
+logger = logging.getLogger(__name__)
+
+
+class MetadataChangeEmitterConfig(BaseModel):
+    gms_server: Optional[str]
+    gms_auth_token: Optional[str]
+    aspects_to_exclude: Optional[List]
+    extra_headers: Optional[Dict[str, str]]
+
+
+class MetadataChangeSyncAction(Action):
+    rest_emitter: DatahubRestEmitter
+    aspects_exclude_set: Set
+    # By default, we exclude the following aspects since different datahub instances have their own encryption keys for
+    # encrypting tokens and secrets, we can't decrypt them even if these values sync to another datahub instance
+    # also, we don't sync execution request aspects because the ingestion recipe might contain datahub secret
+    # that another datahub instance could not decrypt
+    DEFAULT_ASPECTS_EXCLUDE_SET = {
+        "dataHubAccessTokenInfo",
+        "dataHubAccessTokenKey",
+        "dataHubSecretKey",
+        "dataHubSecretValue",
+        "dataHubExecutionRequestInput",
+        "dataHubExecutionRequestKey",
+        "dataHubExecutionRequestResult",
+    }
+
+    @classmethod
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> "Action":
+        action_config = MetadataChangeEmitterConfig.parse_obj(config_dict or {})
+        return cls(action_config, ctx)
+
+    def __init__(self, config: MetadataChangeEmitterConfig, ctx: PipelineContext):
+        self.config = config
+        assert isinstance(self.config.gms_server, str)
+        self.rest_emitter = DatahubRestEmitter(
+            gms_server=self.config.gms_server,
+            token=self.config.gms_auth_token,
+            extra_headers=self.config.extra_headers,
+        )
+        if self.config.aspects_to_exclude is not None:
+            self.aspects_exclude_set = self.DEFAULT_ASPECTS_EXCLUDE_SET.union(
+                set(self.config.aspects_to_exclude)
+            )
+
+    def act(self, event: EventEnvelope) -> None:
+        """
+        This method listens for MetadataChangeLog events, casts it to MetadataChangeProposal,
+        and emits it to another datahub instance
+        """
+        # MetadataChangeProposal only supports UPSERT type for now
+        if event.event_type is METADATA_CHANGE_LOG_EVENT_V1_TYPE:
+            orig_event = cast(MetadataChangeLogClass, event.event)
+            if orig_event.get("aspectName") not in self.aspects_exclude_set:
+                mcp = self.buildMcp(orig_event)
+                if mcp is not None:
+                    self.emit(mcp)
+
+    def buildMcp(
+        self, orig_event: MetadataChangeLogClass
+    ) -> Union[MetadataChangeProposalClass, None]:
+        try:
+            mcp = MetadataChangeProposalClass(
+                entityType=orig_event.get("entityType"),
+                changeType=orig_event.get("changeType"),
+                entityUrn=orig_event.get("entityUrn"),
+                entityKeyAspect=orig_event.get("entityKeyAspect"),
+                aspectName=orig_event.get("aspectName"),
+                aspect=orig_event.get("aspect"),
+            )
+            return mcp
+        except Exception as ex:
+            logger.error(
+                f"error when building mcp from mcl {json.dumps(orig_event.to_obj(), indent=4)}"
+            )
+            logger.error(f"exception: {ex}")
+            return None
+
+    def emit(self, mcp: MetadataChangeProposalClass) -> None:
+        # Create an emitter to DataHub over REST
+        try:
+            # For unit test purpose, moving test_connection from initialization to here
+            # if rest_emitter.server_config is empty, that means test_connection() has not been called before
+            if not self.rest_emitter.server_config:
+                self.rest_emitter.test_connection()
+
+            self.rest_emitter.emit_mcp(mcp)
+            logger.debug("finish emitting an event")
+        except Exception as ex:
+            logger.error(
+                f"error when emitting mcp, {json.dumps(mcp.to_obj(), indent=4)}"
+            )
+            logger.error(f"exception: {ex}")
+
+    def close(self) -> None:
+        pass

--- a/datahub-actions/tests/unit/plugin/action/metadata_change_sync/test_metadata_change_sync.py
+++ b/datahub-actions/tests/unit/plugin/action/metadata_change_sync/test_metadata_change_sync.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from datahub_actions.plugin.action.metadata_change_sync.metadata_change_sync import (
+    MetadataChangeSyncAction,
+)
+from tests.unit.test_helpers import pipeline_context
+
+
+def test_create():
+
+    # Create with gms server
+    MetadataChangeSyncAction.create(
+        {"gms_server": "https://demo.datahubproject.io/"}, pipeline_context
+    )
+
+    # Create with no gms_server
+    with pytest.raises(AssertionError):
+        MetadataChangeSyncAction.create({}, pipeline_context)
+
+    # Create with invalid type config
+    with pytest.raises(ValidationError, match="extra_headers"):
+        MetadataChangeSyncAction.create(
+            {
+                "gms_server": "https://demo.datahubproject.io/",
+                "extra_headers": ["test", "action"],
+            },
+            pipeline_context,
+        )
+
+
+def test_close():
+    # Nothing to Test
+    pass

--- a/docs/actions/metadata_change_sync.md
+++ b/docs/actions/metadata_change_sync.md
@@ -1,0 +1,58 @@
+# Metadata Change Sync
+
+<!-- Set Support Status -->
+
+![Incubating](https://img.shields.io/badge/support%20status-Incubating-red)
+
+## Overview
+
+This Action is a custom action that can convert the incoming MetadataChangeLogEvent_v1 event to MetadataChangeProposal and emit to another datahub instance, the goal of this action is to keep the data of the two datahub instances in sync.
+
+### Capabilities
+
+- Convert incoming MetadataChangeLogEvent_v1 to MetadataChangeProposal and use RestEmitter emit to another datahub instance
+
+### Supported Events
+
+- `MetadataChangeLogEvent_v1`
+
+## Action Quickstart
+
+### Prerequisites
+
+No prerequisites. This action comes pre-loaded with `acryl-datahub-actions`.
+
+### Install the Plugin(s)
+
+This action comes with the Actions Framework by default:
+
+`pip install 'acryl-datahub-actions'`
+
+### Configure the Action Config
+
+Use the following config(s) to get started with this Action.
+
+```yml
+name: "pipeline-name"
+source:
+  # source configs
+type: "metadata_change_sync"
+  config:
+    gms_server: ${DEST_DATAHUB_GMS_URL}
+```
+
+<details>
+  <summary>View All Configuration Options</summary>
+  
+  | Field | Required | Default | Description |
+  | --- | :-: | :-: | --- |
+  | `gms_server` | ✅ | null | Destination GMS server endpoint. |
+  | `gms_auth_token` | ❌ | null | Destination GMS server auth token if the server has METADATA_SERVICE_AUTH_ENABLED enabled. |
+  | `aspects_to_exclude` | ❌ | null | A list of aspects user would like to exclude. |
+  | `extra_headers` | ❌ | null | Extra headers in the emit request with key value format user would like to include. |
+
+</details>
+
+## Troubleshooting
+
+N/A

--- a/docs/actions/metadata_change_sync.md
+++ b/docs/actions/metadata_change_sync.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This Action is a custom action that can convert the incoming MetadataChangeLogEvent_v1 event to MetadataChangeProposal and emit to another datahub instance, the goal of this action is to keep the data of the two datahub instances in sync.
+This Action is a custom action that can convert the incoming MetadataChangeLogEvent_v1 event to MetadataChangeProposal and emit to another datahub instance, the goal of this action is to keep the data of the two datahub instances in sync. This action is a one-way sync and should be run by the source datahub instance.
 
 ### Capabilities
 
@@ -48,7 +48,7 @@ type: "metadata_change_sync"
   | --- | :-: | :-: | --- |
   | `gms_server` | ✅ | null | Destination GMS server endpoint. |
   | `gms_auth_token` | ❌ | null | Destination GMS server auth token if the server has METADATA_SERVICE_AUTH_ENABLED enabled. |
-  | `aspects_to_exclude` | ❌ | null | A list of aspects user would like to exclude. |
+  | `aspects_to_exclude` | ❌ | null | A list of aspects to exclude from the sync. |
   | `extra_headers` | ❌ | null | Extra headers in the emit request with key value format user would like to include. |
 
 </details>

--- a/examples/metadata_change_sync.yaml
+++ b/examples/metadata_change_sync.yaml
@@ -1,0 +1,24 @@
+name: "metadata_change_sync"
+source:
+  type: "kafka"
+  config:
+    connection:
+      bootstrap: ${KAFKA_BOOTSTRAP_SERVER:-localhost:9092}
+      schema_registry_url: ${SCHEMA_REGISTRY_URL:-http://localhost:8081}
+filter:
+  event_type: "MetadataChangeLogEvent_v1"
+  event:
+    changeType: "UPSERT"
+action:
+  type: "metadata_change_sync"
+  config:
+    gms_server: ${DEST_DATAHUB_GMS_URL}
+    # If you have METADATA_SERVICE_AUTH_ENABLED enabled in GMS, you'll need to configure the auth token here
+    gms_auth_token: ${DEST_DATAHUB_GMS_TOKEN}
+    # you can provide a list of aspects you would like to exclude
+    # By default, we are excluding these aspects:
+    # dataHubAccessTokenInfo, dataHubAccessTokenKey, dataHubSecretKey, dataHubSecretValue, dataHubExecutionRequestInput
+    # dataHubExecutionRequestKey, dataHubExecutionRequestResult
+    aspects_to_exclude: []
+    # you can provide extra headers in the request in key value format
+    extra_headers: {}


### PR DESCRIPTION
This PR implements a new action that can listen to the `MetadataChangeLogEvent_v1` events and convert it to `MetadataChangeProposal` and use the Python emitter SDK to emit the proposal to another datahub instance.

The configuration file takes `gms_server` and `gms_auth_token` to emit the proposal to another datahub instance, since `MetadataChangeProposal` currently only supports the `UPSERT` change type, we'll only focus on `MetadataChangeLogEvent_v1` with the `UPSERT` type.

Tests and doc for the changes have been added