### PR TITLE
reporting: suppress vulnerability reporting of full image to make sli…

### DIFF
--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -106,38 +106,38 @@ jobs:
           push: ${{ needs.setup.outputs.publish == 'true' }}
           build-args:
             "DOCKER_BASE_IMAGE=${{ steps.action_tag.outputs.tag }}"
-  image_scan:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: "[Monitoring] Scan action images for vulnerabilities"
-    runs-on: ubuntu-latest
-    needs: [setup, push_to_registries]
-    steps:
-      - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: actions/checkout@v3
-      - name: Download image
-        uses: ishworkh/docker-image-artifact-download@v1
-        if: ${{ needs.setup.outputs.publish != 'true' }}
-        with:
-          image: acryldata/datahub-actions:${{ needs.setup.outputs.unique_tag }}
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_OFFLINE_SCAN: true
-        with:
-          image-ref: acryldata/datahub-actions:${{ needs.setup.outputs.unique_tag }}
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          vuln-type: "os,library"          
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: 'trivy-results.sarif'
+  # image_scan:
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+  #   name: "[Monitoring] Scan action images for vulnerabilities"
+  #   runs-on: ubuntu-latest
+  #   needs: [setup, push_to_registries]
+  #   steps:
+  #     - name: Checkout # adding checkout step just to make trivy upload happy
+  #       uses: actions/checkout@v3
+  #     - name: Download image
+  #       uses: ishworkh/docker-image-artifact-download@v1
+  #       if: ${{ needs.setup.outputs.publish != 'true' }}
+  #       with:
+  #         image: acryldata/datahub-actions:${{ needs.setup.outputs.unique_tag }}
+  #     - name: Run Trivy vulnerability scanner
+  #       uses: aquasecurity/trivy-action@master
+  #       env:
+  #         TRIVY_OFFLINE_SCAN: true
+  #       with:
+  #         image-ref: acryldata/datahub-actions:${{ needs.setup.outputs.unique_tag }}
+  #         format: 'template'
+  #         template: '@/contrib/sarif.tpl'
+  #         output: 'trivy-results.sarif'
+  #         severity: 'CRITICAL,HIGH'
+  #         ignore-unfixed: true
+  #         vuln-type: "os,library"          
+  #     - name: Upload Trivy scan results to GitHub Security tab
+  #       uses: github/codeql-action/upload-sarif@v2
+  #       with:
+  #         sarif_file: 'trivy-results.sarif'
   image_scan_slim:
     permissions:
       contents: read # for actions/checkout to fetch code


### PR DESCRIPTION
…m image vulnerabilities clear

The current code scanning tab makes it hard to understand which vulnerabilities are being reported from which image. 
Turning off reporting temporarily for the full image, so we can see the slim image vulnerabilities clearly.