### PR TITLE
feat(logging): Improve general logging and add more logging in metadata change sync action

### DIFF
--- a/datahub-actions/src/datahub_actions/entrypoints.py
+++ b/datahub-actions/src/datahub_actions/entrypoints.py
@@ -38,16 +38,14 @@ MAX_CONTENT_WIDTH = 120
 
 
 class LogFilter(logging.Filter):
-    """Filters (lets through) all messages with level < LEVEL"""
+    """Filters (lets through) all messages with level <= LEVEL"""
 
     # https://stackoverflow.com/questions/1383254/logging-streamhandler-and-standard-streams
     def __init__(self, level):
         self.level = level
 
     def filter(self, record):
-        # "<" instead of "<=": since logger.setLevel is inclusive, this should
-        # be exclusive
-        return record.levelno < self.level
+        return record.levelno <= self.level
 
 
 @click.group(
@@ -105,7 +103,7 @@ def datahub_actions(
     # 2. Setup the stream handler with formatter. By default, stream handler will log everything to stderr, we want to separate the info level and below to stdout and above to stderr
     formatter = logging.Formatter(BASE_LOGGING_FORMAT)
     info_handler = logging.StreamHandler(sys.stdout)
-    info_handler.addFilter(LogFilter(logging.WARNING))
+    info_handler.addFilter(LogFilter(logging.INFO))
     info_handler.setLevel(logging.INFO)
     info_handler.setFormatter(formatter)
     error_handler = logging.StreamHandler(sys.stderr)

--- a/datahub-actions/src/datahub_actions/entrypoints.py
+++ b/datahub-actions/src/datahub_actions/entrypoints.py
@@ -15,6 +15,7 @@
 import logging
 import platform
 import sys
+from logging.handlers import TimedRotatingFileHandler
 
 import click
 import stackprinter
@@ -30,9 +31,23 @@ logger = logging.getLogger(__name__)
 BASE_LOGGING_FORMAT = (
     "[%(asctime)s] %(levelname)-8s {%(name)s:%(lineno)d} - %(message)s"
 )
+LOGGING_FILE_LOCATION = "/tmp/datahub/logs/actions/actions.out"
 logging.basicConfig(format=BASE_LOGGING_FORMAT)
 
 MAX_CONTENT_WIDTH = 120
+
+
+class LogFilter(logging.Filter):
+    """Filters (lets through) all messages with level < LEVEL"""
+
+    # https://stackoverflow.com/questions/1383254/logging-streamhandler-and-standard-streams
+    def __init__(self, level):
+        self.level = level
+
+    def filter(self, record):
+        # "<" instead of "<=": since logger.setLevel is inclusive, this should
+        # be exclusive
+        return record.levelno < self.level
 
 
 @click.group(
@@ -87,16 +102,31 @@ def datahub_actions(
 
     # 1. Create 'datahub' parent logger.
     datahub_logger = logging.getLogger("datahub_actions")
-    # 2. Setup the stream handler with formatter.
-    stream_handler = logging.StreamHandler()
+    # 2. Setup the stream handler with formatter. By default, stream handler will log everything to stderr, we want to separate the info level and below to stdout and above to stderr
     formatter = logging.Formatter(BASE_LOGGING_FORMAT)
-    stream_handler.setFormatter(formatter)
-    datahub_logger.addHandler(stream_handler)
+    info_handler = logging.StreamHandler(sys.stdout)
+    info_handler.addFilter(LogFilter(logging.WARNING))
+    info_handler.setLevel(logging.INFO)
+    info_handler.setFormatter(formatter)
+    error_handler = logging.StreamHandler(sys.stderr)
+    error_handler.setLevel(logging.WARNING)
+    error_handler.setFormatter(formatter)
+    # Create a handler for the log file
+    file_handler = TimedRotatingFileHandler(
+        LOGGING_FILE_LOCATION, when="midnight", interval=1, backupCount=10
+    )
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(formatter)
+    datahub_logger.addHandler(info_handler)
+    datahub_logger.addHandler(error_handler)
+    datahub_logger.addHandler(file_handler)
     # 3. Turn off propagation to the root handler.
     datahub_logger.propagate = False
     # 4. Adjust log-levels.
     if debug or get_boolean_env_variable("DATAHUB_DEBUG", False):
         logging.getLogger().setLevel(logging.INFO)
+        info_handler.setLevel(logging.DEBUG)
+        file_handler.setLevel(logging.DEBUG)
         datahub_logger.setLevel(logging.DEBUG)
     else:
         logging.getLogger().setLevel(logging.WARNING)

--- a/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
@@ -58,8 +58,13 @@ class MetadataChangeSyncAction(Action):
             self.aspects_exclude_set = self.DEFAULT_ASPECTS_EXCLUDE_SET.union(
                 set(self.config.aspects_to_exclude)
             )
+        extra_headers_keys = (
+            list(self.config.extra_headers.keys())
+            if self.config.extra_headers
+            else None
+        )
         logger.info(
-            f"MetadataChangeSyncAction configured to emit mcp to gms server {self.config.gms_server} with extra headers {list(self.config.extra_headers.keys())} and aspects to exclude {self.aspects_exclude_set}"
+            f"MetadataChangeSyncAction configured to emit mcp to gms server {self.config.gms_server} with extra headers {extra_headers_keys} and aspects to exclude {self.aspects_exclude_set}"
         )
 
     def act(self, event: EventEnvelope) -> None:

--- a/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
@@ -59,7 +59,7 @@ class MetadataChangeSyncAction(Action):
                 set(self.config.aspects_to_exclude)
             )
         logger.info(
-            f"MetadataChangeSyncAction configured to emit mcp to gms server {self.config.gms_server} with extra headers {self.config.extra_headers}"
+            f"MetadataChangeSyncAction configured to emit mcp to gms server {self.config.gms_server} with extra headers {self.config.extra_headers.keys} and aspects to exclude {self.aspects_exclude_set}"
         )
 
     def act(self, event: EventEnvelope) -> None:

--- a/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
@@ -54,10 +54,11 @@ class MetadataChangeSyncAction(Action):
             token=self.config.gms_auth_token,
             extra_headers=self.config.extra_headers,
         )
-        if self.config.aspects_to_exclude is not None:
-            self.aspects_exclude_set = self.DEFAULT_ASPECTS_EXCLUDE_SET.union(
-                set(self.config.aspects_to_exclude)
-            )
+        self.aspects_exclude_set = (
+            self.DEFAULT_ASPECTS_EXCLUDE_SET.union(set(self.config.aspects_to_exclude))
+            if self.config.aspects_to_exclude
+            else self.DEFAULT_ASPECTS_EXCLUDE_SET
+        )
         extra_headers_keys = (
             list(self.config.extra_headers.keys())
             if self.config.extra_headers

--- a/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
@@ -59,7 +59,7 @@ class MetadataChangeSyncAction(Action):
                 set(self.config.aspects_to_exclude)
             )
         logger.info(
-            f"MetadataChangeSyncAction configured to emit mcp to gms server {self.config.gms_server} with extra headers {self.config.extra_headers.keys} and aspects to exclude {self.aspects_exclude_set}"
+            f"MetadataChangeSyncAction configured to emit mcp to gms server {self.config.gms_server} with extra headers {list(self.config.extra_headers.keys())} and aspects to exclude {self.aspects_exclude_set}"
         )
 
     def act(self, event: EventEnvelope) -> None:


### PR DESCRIPTION
This PR has the following improvement for logging:

1. The current stream_handler by default logs everything to `stderr`, it's not a desirable behavior when we want to distinguish errors from info, for example in logging explorer in GKE. To address this, we separate into `info_handler` which directs output to `stdout`, and `error_handler` directs output to `stderr`. By adding a filter class `LogFilter` to `info_handler` we'll be able to let through messages below the level we set.

2. The current datahub-actions logging only logs to the console but not keeping a record in file, the `start.sh` in `docker/datahub-actions` has `touch /tmp/datahub/logs/actions/actions.out` that the file is created but it's never being used. We use `TimedRotatingFileHandler` that outputs the logging to this file and also rotates every day at midnight and keep the backup for 10 days so that we can retrieve the actions log easily from the file.

3. We also add more logging to `metadata_change_sync.py` to have more useful information.