### PR TITLE
chore: pin acryl-executor version

### DIFF
--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -71,7 +71,7 @@ plugins: Dict[str, Set[str]] = {
     "kafka": set(),  # included by default
     # Action Plugins
     "executor": {
-        "acryl-executor>=0.0.3.6",
+        "acryl-executor==0.0.3.9",
     },
     "slack": {
         "slack-bolt>=1.15.5",


### PR DESCRIPTION
Seems like there's an issue in 0.0.3.10.
