### PR TITLE
fix(notifications): fix wrong urls in ms teams notifications

### DIFF
--- a/datahub-actions/src/datahub_actions/utils/datahub_util.py
+++ b/datahub-actions/src/datahub_actions/utils/datahub_util.py
@@ -65,3 +65,7 @@ def make_datahub_url(urn: str, base_url: str) -> str:
     entity_type = entity_type_from_urn(urn)
     urn = urn.replace("/", "%2F")
     return f"{base_url}/{ENTITY_TYPE_TO_URL_PATH_MAP[entity_type]}/{urn}/"
+
+def make_entity_url(urn: str, entity_type: str, base_url: str) -> str:
+    urn = urn.replace("/", "%2F")
+    return f"{base_url}/{entity_type}/{urn}"

--- a/datahub-actions/src/datahub_actions/utils/social_util.py
+++ b/datahub-actions/src/datahub_actions/utils/social_util.py
@@ -7,6 +7,7 @@ from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import EntityChangeEventClass as EntityChangeEvent
 from datahub.utilities.urns.urn import Urn
 
+from datahub_actions.utils.datahub_util import make_entity_url
 from datahub_actions.utils.name_resolver import (
     get_entity_name_from_urn,
     get_entity_qualifier_from_urn,
@@ -108,20 +109,20 @@ def get_message_from_entity_change_event(
         parent_specialized_type = get_entity_qualifier_from_urn(
             str(parent_entity_urn), datahub_graph
         )
-        parent_entity_url = f"{datahub_base_url}/{parent_entity_urn.get_type()}/{parent_entity_urn}/Schema?schemaFilter={entity_name}"
+        parent_entity_url = f"{make_entity_url(str(parent_entity_urn), parent_entity_urn.get_type(), datahub_base_url)}/Schema?schemaFilter={entity_name}"
         entity_message_trailer = f"{entity_name} of {parent_specialized_type} {make_url_with_title(title=parent_entity_name, url=parent_entity_url, channel=channel)}"
     elif event.entityType == "dataFlow":
-        entity_url = f"{datahub_base_url}/pipelines/{event.entityUrn}"
+        entity_url = make_entity_url(event.entityUrn, "pipelines", datahub_base_url)
         entity_message_trailer = make_url_with_title(
             title=entity_name, url=entity_url, channel=channel
         )
     elif event.entityType == "dataJob":
-        entity_url = f"{datahub_base_url}/tasks/{event.entityUrn}"
+        entity_url = make_entity_url(event.entityUrn, "tasks", datahub_base_url)
         entity_message_trailer = make_url_with_title(
             title=entity_name, url=entity_url, channel=channel
         )
     else:
-        entity_url = f"{datahub_base_url}/{event.entityType}/{event.entityUrn}"
+        entity_url = make_entity_url(event.entityUrn, event.entityType, datahub_base_url)
         entity_message_trailer = make_url_with_title(
             title=entity_name, url=entity_url, channel=channel
         )


### PR DESCRIPTION
Links for datasets like a file are not correct in Teams notifications.
Part of delimiters "/" in a URL should be replaced on "%2F" symbols.

For example, before changes:
http://xx.xx.xx.xx:9002/dataset/urn:li:dataset:(urn:li:dataPlatform:dbfs,/dream_team/cross_banner,PROD)/Schema?schemaFilter=ban_1_Banner

And after changes:
http://xx.xx.xx.xx:9002/dataset/urn:li:dataset:(urn:li:dataPlatform:dbfs,%2Fdream_team%2Fcross_banner,PROD)/Schema?schemaFilter=ban_1_Banner