### PR TITLE
feat: add configuration for Kafka consumer groups via environment variables

### DIFF
--- a/docker/config/executor.yaml
+++ b/docker/config/executor.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: "ingestion_executor" 
+name: ${DATAHUB_ACTIONS_INGESTION_EXECUTOR_CONSUMER_GROUP_ID:-ingestion_executor}
 source:
   type: "kafka"
   config:

--- a/docker/config/slack_action.yaml
+++ b/docker/config/slack_action.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: datahub_slack_action
+name: ${DATAHUB_ACTIONS_SLACK_CONSUMER_GROUP_ID:-datahub_slack_action}
 enabled: ${DATAHUB_ACTIONS_SLACK_ENABLED:-false}
 source:
   type: "kafka"

--- a/docker/config/teams_action.yaml
+++ b/docker/config/teams_action.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: datahub_teams_action
+name: ${DATAHUB_ACTIONS_TEAMS_CONSUMER_GROUP_ID:-datahub_teams_action}
 enabled: ${DATAHUB_ACTIONS_TEAMS_ENABLED:-false}
 source:
   type: "kafka"


### PR DESCRIPTION
To have configurable consumer groups, this PR introduces three new environment variables which are used for the names of the three existing pipelines - the names of the pipelines are used for the consumer groups:

DATAHUB_ACTIONS_INGESTION_EXECUTOR_CONSUMER_GROUP_ID (ingestion_executor)
DATAHUB_ACTIONS_SLACK_CONSUMER_GROUP_ID (datahub_slack_action)
DATAHUB_ACTIONS_TEAMS_CONSUMER_GROUP_ID (datahub_teams_action)

If the environment variables are not provided the existing pipeline names will be used by default.

There will be another PR in the datahub-helm repository which will use these environment variables.

edit: The [other PR](https://github.com/acryldata/datahub-helm/pull/436) in the datahub-helm repository.