### PR TITLE
datahub actions fail when setting up new environment because of pydantic version issue. Datahub actions doesn't support pydantic 2 fully.

### DIFF
--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -39,7 +39,7 @@ base_requirements = {
     "mypy_extensions>=0.4.3",
     # Actual dependencies.
     "typing-inspect",
-    "pydantic>=1.5.1",
+    "pydantic<2",
     "dictdiffer",
     "ratelimit",
 }


### PR DESCRIPTION
datahub actions give validation errors for optional fields when using pydantic version 2. 
fixing the requirement to < version 2 (instead of > 1.15) to avoid such issues.
this is as mentioned in issue #113