### PR TITLE
Kafka consumer reliability/performance improvements

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/source/kafka/utils.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/kafka/utils.py
@@ -1,0 +1,26 @@
+import logging
+import time
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+def with_retry(max_attempts: int, max_backoff: float, func: Callable, *args, **kwargs) -> Any:  # type: ignore
+    curr_attempt = 0
+    backoff = 0.3
+
+    while curr_attempt < max_attempts:
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            logger.error(str(e))
+
+            curr_attempt = curr_attempt + 1
+            if curr_attempt >= max_attempts:
+                logger.warning("kafka event source: exhausted all attempts.")
+                return
+
+            backoff = backoff * 2
+            if backoff > max_backoff:
+                backoff = max_backoff
+            time.sleep(backoff)

--- a/datahub-actions/src/datahub_actions/source/event_source.py
+++ b/datahub-actions/src/datahub_actions/source/event_source.py
@@ -48,7 +48,7 @@ class EventSource(Closeable, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def ack(self, event: EventEnvelope) -> None:
+    def ack(self, event: EventEnvelope, processed: bool = True) -> None:
         """
         Acknowledges the processing of an individual event by the Actions Framework
         """

--- a/datahub-actions/tests/unit/test_helpers.py
+++ b/datahub-actions/tests/unit/test_helpers.py
@@ -138,7 +138,7 @@ class TestEventSource(EventSource):
             EventEnvelope("TestEvent", TestEvent("value"), {}),
         ]
 
-    def ack(self, event: EventEnvelope) -> None:
+    def ack(self, event: EventEnvelope, processed: bool = True) -> None:
         self.ack_count = self.ack_count + 1
 
     def close(self) -> None:
@@ -221,7 +221,7 @@ class StoppableEventSource(EventSource):
                 "MetadataChangeLogEvent_v1", metadata_change_log_event, {}
             )
 
-    def ack(self, event: EventEnvelope) -> None:
+    def ack(self, event: EventEnvelope, processed: bool = True) -> None:
         pass
 
     def close(self) -> None:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Reliability: check/retry commit failures. By default, commit is asynchronous, and no error checking/logging is performed. This PR converts the commit call to a synchronous call, checks if any partition failed to commit, logs the errors, and retries failed commits.

* Performance: originally, actions consumer commits offset after passing every single message to the user. Commit is very expensive by itself, and it causes a network round-trip, so processing of a heavily backed up topic may take a very long time. This changes the behavior of the consumer such that it only commits after messages that the user cares about, and all other messages are committed periodically, according to the standard auto-commit configuration.

@jjoyce0510 