### PR TITLE
feat: add environment variables to configure monitoring in Docker image

### DIFF
--- a/docker/datahub-actions/start.sh
+++ b/docker/datahub-actions/start.sh
@@ -16,6 +16,8 @@
 
 SYS_CONFIGS_PATH="${DATAHUB_ACTIONS_SYSTEM_CONFIGS_PATH:-/etc/datahub/actions/system/conf}"
 USER_CONFIGS_PATH="${DATAHUB_ACTIONS_USER_CONFIGS_PATH:-/etc/datahub/actions/conf}"
+MONITORING_ENABLED="${DATAHUB_ACTIONS_MONITORING_ENABLED:-false}"
+MONITORING_PORT="${DATAHUB_ACTIONS_MONITORING_PORT:-8000}"
 
 touch /tmp/datahub/logs/actions/actions.out
 
@@ -60,4 +62,8 @@ else
     echo "No user action configurations found. Not starting user actions."
 fi
 
-datahub-actions actions $config_files
+if [ "$MONITORING_ENABLED" = true ]; then
+    datahub-actions --enable-monitoring --monitoring-port "$MONITORING_PORT" actions $config_files
+else
+    datahub-actions actions $config_files
+fi


### PR DESCRIPTION
I saw that the CLI of datahub-actions [contains an option](https://github.com/acryldata/datahub-actions/blob/54a568b556fd2b799cd99a25abad3b45f9756c71/datahub-actions/src/datahub_actions/entrypoints.py#L45-L59) to enable a monitoring endpoint - this PR introduces two new environment variables (DATAHUB_ACTIONS_MONITORING_ENABLED and DATAHUB_ACTIONS_MONITORING_PORT) which allows to enable this endpoint when running the Docker image.

There will be a second PR for the datahub-helm repository which will make use of these two environment variables.

edit: Here is the other PR: https://github.com/acryldata/datahub-helm/pull/473