### PR TITLE
feat(actions): Adding support for MCL Timeseries

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 ENTITY_CHANGE_EVENT_NAME = "entityChangeEvent"
 DEFAULT_TOPIC_ROUTES = {
     "mcl": "MetadataChangeLog_Versioned_v1",
+    "mcl_timeseries": "MetadataChangeLog_Timeseries_v1",
     "pe": "PlatformEvent_v1",
 }
 
@@ -188,6 +189,13 @@ class KafkaEventSource(EventSource):
             else:
                 if "mcl" in topic_routes and msg.topic() == topic_routes["mcl"]:
                     yield from self.handle_mcl(msg)
+                if (
+                    "mcl_timeseries" in topic_routes
+                    and msg.topic() == topic_routes["mcl_timeseries"]
+                ):
+                    yield from self.handle_mcl(
+                        msg
+                    )  # Handle timeseries in the same way as usual MCL.
                 elif "pe" in topic_routes and msg.topic() == topic_routes["pe"]:
                     yield from self.handle_pe(msg)
 

--- a/docs/sources/kafka-event-source.md
+++ b/docs/sources/kafka-event-source.md
@@ -62,6 +62,7 @@ source:
     # Topic Routing - which topics to read from.
     topic_routes:
       mcl: ${METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME:-MetadataChangeLog_Versioned_v1} # Topic name for MetadataChangeLogEvent_v1 events. 
+      mcl_timeseries: ${METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME:-MetadataChangeLog_Timeseries_v1} # Topic name for MetadataChangeLogEvent_v1 timeseries events. 
       pe: ${PLATFORM_EVENT_TOPIC_NAME:-PlatformEvent_v1} # Topic name for PlatformEvent_v1 events. 
 action:
   # action configs
@@ -75,7 +76,8 @@ action:
   | `connection.bootstrap` | ✅ | N/A | The Kafka bootstrap URI, e.g. `localhost:9092`. |
   | `connection.schema_registry_url` | ✅ | N/A | The URL for the Kafka schema registry, e.g. `http://localhost:8081` |
   | `connection.consumer_config` | ❌ | {} | A set of key-value pairs that represents arbitrary Kafka Consumer configs |
-  | `topic_routes.mcl` | ❌  | `MetadataChangeLogEvent_v1` | The name of the topic containing MetadataChangeLog events |
+  | `topic_routes.mcl` | ❌  | `MetadataChangeLog_Versioned_v1` | The name of the topic containing versionined MetadataChangeLog events |
+  | `topic_routes.mcl_timeseries` | ❌  | `MetadataChangeLog_Timeseries_v1` | The name of the topic containing timeseries MetadataChangeLog events |
   | `topic_routes.pe` | ❌ | `PlatformEvent_v1` | The name of the topic containing PlatformEvent events |
 </details>
 


### PR DESCRIPTION

## Summary

In this PR, we add support for wiring in MCL Timeseries topic to datahub actions. 


## QA

Verified that timeseries events are streaming through using the hello_world action when enabled. 

```
{
    "event_type": "MetadataChangeLogEvent_v1",
    "event": {
        "entityType": "assertion",
        "entityUrn": "urn:li:assertion:358c683782c93c2fc2bd4bdd4fdb0153",
        "changeType": "UPSERT",
        "aspectName": "assertionRunEvent",
        "aspect": {
            "value": "{\"result\":{\"type\":\"SUCCESS\",\"nativeResults\":{}},\"assertionUrn\":\"urn:li:assertion:358c683782c93c2fc2bd4bdd4fdb0153\",\"timestampMillis\":1675155843000,\"asserteeUrn\":\"urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)\",\"runId\":\"2021-12-28T12:00:00Z\",\"partitionSpec\":{\"type\":\"PARTITION\",\"partition\":\"{\\\"category\\\": \\\"catA\\\"}\"},\"batchSpec\":{\"limit\":10,\"nativeBatchId\":\"c8f12129f2e57412eee5fb8656154d05\",\"customProperties\":{\"data_asset_name\":\"data__foo1__asset\",\"datasource_name\":\"my_hive_datasource\"}},\"status\":\"COMPLETE\"}",
            "contentType": "application/json"
        },
        "systemMetadata": {
            "lastObserved": 1719854699981,
            "runId": "file-2024_07_01-10_24_59",
            "lastRunId": "no-run-id-provided"
        },
        "created": {
            "time": 1719854700775,
            "actor": "urn:li:corpuser:__datahub_system"
        }
    },
    "meta": {
        "kafka": {
            "topic": "MetadataChangeLog_Timeseries_v1",
            "offset": 8,
            "partition": 0
        }
    }
}
```