### PR TITLE
fix(retries): move handle failure code outside of while loop

### DIFF
--- a/datahub-actions/src/datahub_actions/pipeline/pipeline.py
+++ b/datahub-actions/src/datahub_actions/pipeline/pipeline.py
@@ -217,15 +217,15 @@ class Pipeline:
                 )
                 curr_attempt = curr_attempt + 1
 
-            logger.error(
-                f"Failed to process event after {self._retry_count} retries. event type: {enveloped_event.event_type}, pipeline name: {self.name}. Handling failure..."
-            )
+        logger.error(
+            f"Failed to process event after {self._retry_count} retries. event type: {enveloped_event.event_type}, pipeline name: {self.name}. Handling failure..."
+        )
 
-            # Increment failed event count.
-            self._stats.increment_failed_event_count()
+        # Increment failed event count.
+        self._stats.increment_failed_event_count()
 
-            # Finally, handle the failure
-            self._handle_failure(enveloped_event)
+        # Finally, handle the failure
+        self._handle_failure(enveloped_event)
 
         return retval
 


### PR DESCRIPTION
The handle failure code is in the while loop, so after a single failure it will run the _handle_failure function. The retries will still happen if the `failure_mode` is set to `CONTINUE`, but if it's set to `THROW` it will throw an exception after the first failure. With these lines outside of the loop, it will still log when an attempt fails and then once all retries are exhausted it will print the actual failure message and throw and exception if set to `THROW` mode.