### PR TITLE
feat(actions): add docs propagation action for columns

### DIFF
--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -19,9 +19,6 @@ on:
     types: [published, edited]
   workflow_dispatch:
 
-# env:
-#   DOCKER_CHANGES: ${{ github.event_name != 'workflow_dispatch' && (github.event.pull_request.changed_files > 0 || github.event.head_commit.modified > 0) && contains(github.event.pull_request.changed_files || github.event.head_commit.modified, 'docker/') }}
-
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -29,12 +26,9 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       publish: ${{ steps.publish.outputs.publish }}
       unique_tag: ${{ steps.tag.outputs.unique_tag }}
-      build_docker: ${{ env.DOCKER_CHANGES }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        # with:
-        #   fetch-depth: 0
       - name: Compute Tag
         id: tag
         run: |
@@ -51,14 +45,9 @@ jobs:
         run: |
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "publish=${{ env.ENABLE_PUBLISH != '' }}" >> "$GITHUB_OUTPUT"
-      # - name: Check for changes in docker directory
-      #   id: check_docker_changes
-      #   run: |
-      #     git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^docker/' && echo "build_docker=true" >> "$GITHUB_OUTPUT" || echo "build_docker=false" >> "$GITHUB_OUTPUT"
   regular_image:
     name: Build & Push Image to DockerHub
     runs-on: ubuntu-latest
-    # if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.build_docker == 'true' }}
     needs: setup
     steps:
       - name: Check out the repo
@@ -71,8 +60,6 @@ jobs:
             acryldata/datahub-actions
           tags: |
             type=raw,value=${{ needs.setup.outputs.tag }}
-          # tag-custom: ${{ needs.setup.outputs.tag }}
-          # tag-custom-only: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         if: ${{ needs.setup.outputs.publish == 'true' }}
@@ -98,7 +85,6 @@ jobs:
   slim_image:
     name: Build & Push Image to DockerHub (slim)
     runs-on: ubuntu-latest
-    # if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.build_docker == 'true' }}
     needs: setup
     steps:
       - name: Check out the repo (slim)
@@ -199,9 +185,6 @@ jobs:
         uses: ishworkh/docker-image-artifact-download@v1
         with:
           image: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
-      # - name: Download image (slim)
-      #   uses: ishworkh/docker-image-artifact-download@v1
-      #   with:
       - name: Run Trivy vulnerability scanner (slim)
         uses: aquasecurity/trivy-action@master
         env:

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -19,8 +19,8 @@ on:
     types: [published, edited]
   workflow_dispatch:
 
-env:
-  DOCKER_CHANGES: ${{ github.event_name != 'workflow_dispatch' && (github.event.pull_request.changed_files > 0 || github.event.head_commit.modified > 0) && contains(github.event.pull_request.changed_files || github.event.head_commit.modified, 'docker/') }}
+# env:
+#   DOCKER_CHANGES: ${{ github.event_name != 'workflow_dispatch' && (github.event.pull_request.changed_files > 0 || github.event.head_commit.modified > 0) && contains(github.event.pull_request.changed_files || github.event.head_commit.modified, 'docker/') }}
 
 jobs:
   setup:
@@ -58,7 +58,7 @@ jobs:
   regular_image:
     name: Build & Push Image to DockerHub
     runs-on: ubuntu-latest
-    if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.build_docker == 'true' }}
+    # if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.build_docker == 'true' }}
     needs: setup
     steps:
       - name: Check out the repo
@@ -95,7 +95,7 @@ jobs:
   slim_image:
     name: Build & Push Image to DockerHub (slim)
     runs-on: ubuntu-latest
-    if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.build_docker == 'true' }}
+    # if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.build_docker == 'true' }}
     needs: setup
     steps:
       - name: Check out the repo (slim)

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -169,12 +169,12 @@ jobs:
     name: '[Monitoring] Scan slim action images for vulnerabilities'
     runs-on: ubuntu-latest
     needs: [setup, slim_image]
+    if: needs.setup.outputs.publish == 'true'
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
         uses: actions/checkout@v4
       - name: Download image (slim)
         uses: ishworkh/docker-image-artifact-download@v1
-        if: ${{ needs.setup.outputs.publish != 'true' }}
         with:
           image: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
       - name: Run Trivy vulnerability scanner (slim)

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -186,14 +186,6 @@ jobs:
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
         uses: actions/checkout@v4
-      - name: Set image reference
-        id: set_image_ref
-        run: |
-          if [[ "${{ needs.setup.outputs.publish }}" == "true" ]]; then
-            echo "IMAGE_REF=acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "IMAGE_REF=datahub-actions-slim:local" >> $GITHUB_OUTPUT
-          fi
       - name: Download artifact (if not publishing)
         if: needs.setup.outputs.publish != 'true'
         uses: actions/download-artifact@v3
@@ -206,18 +198,16 @@ jobs:
         if: needs.setup.outputs.publish == 'true'
         uses: ishworkh/docker-image-artifact-download@v1
         with:
-          image: ${{ steps.set_image_ref.outputs.IMAGE_REF }}
+          image: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
       # - name: Download image (slim)
       #   uses: ishworkh/docker-image-artifact-download@v1
       #   with:
-      #     image: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
       - name: Run Trivy vulnerability scanner (slim)
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_OFFLINE_SCAN: true
         with:
-          image-ref: ${{ steps.set_image_ref.outputs.IMAGE_REF }}
-          # image-ref: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
+          image-ref: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -218,3 +218,58 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+  smoke_test:
+    name: Run Smoke Tests
+    runs-on: ubuntu-latest
+    needs: [setup, slim_image]
+    steps:
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove 'dotnet-*' azure-cli || true
+          sudo rm -rf /usr/local/lib/android/ || true
+          sudo docker image prune -a -f || true
+      - name: Disk Check
+        run: df -h . && docker images
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Download artifact (if not publishing)
+        if: needs.setup.outputs.publish != 'true'
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-image
+      - name: Load Docker image (if not publishing)
+        if: needs.setup.outputs.publish != 'true'
+        run: docker load < image.tar
+      - name: Download image (if publishing)
+        if: needs.setup.outputs.publish == 'true'
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
+      - name: run quickstart
+        env:
+          DATAHUB_TELEMETRY_ENABLED: false
+          DATAHUB_ACTIONS_IMAGE: acryldata/datahub-actions-slim
+          DATAHUB_ACTIONS_VERSION: ${{ needs.setup.outputs.unique_tag }}
+          ACTIONS_EXTRA_PACKAGES: 'acryl-datahub-actions[executor]==0.0.13 acryl-datahub-actions==0.0.13 acryl-datahub==0.10.5'
+          ACTIONS_CONFIG: 'https://raw.githubusercontent.com/acryldata/datahub-actions/main/docker/config/executor.yaml'
+        run: |
+          ./smoke-test/run-quickstart.sh
+      - name: Disk Check
+        run: df -h . && docker images
+      - name: Smoke test
+        env:
+          RUN_QUICKSTART: false
+          DATAHUB_ACTIONS_VERSION: ${{ needs.setup.outputs.unique_tag }}
+        run: |
+          echo "$DATAHUB_ACTIONS_VERSION"
+          ./smoke-test/smoke.sh

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -26,9 +26,12 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       publish: ${{ steps.publish.outputs.publish }}
       unique_tag: ${{ steps.tag.outputs.unique_tag }}
+      build_docker: ${{ steps.check_docker_changes.outputs.build_docker }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Compute Tag
         id: tag
         run: |
@@ -45,10 +48,14 @@ jobs:
         run: |
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "publish=${{ env.ENABLE_PUBLISH != '' }}" >> "$GITHUB_OUTPUT"
+      - name: Check for changes in docker directory
+        id: check_docker_changes
+        run: |
+          git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^docker/' && echo "build_docker=true" >> "$GITHUB_OUTPUT" || echo "build_docker=false" >> "$GITHUB_OUTPUT"
   regular_image:
     name: Build & Push Image to DockerHub
     runs-on: ubuntu-latest
-    if: ${{ needs.setup.outputs.publish == 'true' }}
+    if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.build_docker == 'true' }}
     needs: setup
     steps:
       - name: Check out the repo
@@ -68,6 +75,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
+        if: ${{ needs.setup.outputs.publish == 'true' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.ACRYL_DOCKER_USERNAME }}
@@ -84,7 +92,7 @@ jobs:
   slim_image:
     name: Build & Push Image to DockerHub (slim)
     runs-on: ubuntu-latest
-    if: ${{ needs.setup.outputs.publish == 'true' }}
+    if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.build_docker == 'true' }}
     needs: setup
     steps:
       - name: Check out the repo (slim)
@@ -103,6 +111,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub (slim)
         uses: docker/login-action@v2
+        if: ${{ needs.setup.outputs.publish == 'true' }}
         with:
           username: ${{ secrets.ACRYL_DOCKER_USERNAME }}
           password: ${{ secrets.ACRYL_DOCKER_PASSWORD }}

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -19,6 +19,9 @@ on:
     types: [published, edited]
   workflow_dispatch:
 
+env:
+  DOCKER_CHANGES: ${{ github.event_name != 'workflow_dispatch' && (github.event.pull_request.changed_files > 0 || github.event.head_commit.modified > 0) && contains(github.event.pull_request.changed_files || github.event.head_commit.modified, 'docker/') }}
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -26,12 +29,12 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       publish: ${{ steps.publish.outputs.publish }}
       unique_tag: ${{ steps.tag.outputs.unique_tag }}
-      build_docker: ${{ steps.check_docker_changes.outputs.build_docker }}
+      build_docker: ${{ env.DOCKER_CHANGES }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+        # with:
+        #   fetch-depth: 0
       - name: Compute Tag
         id: tag
         run: |
@@ -48,10 +51,10 @@ jobs:
         run: |
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "publish=${{ env.ENABLE_PUBLISH != '' }}" >> "$GITHUB_OUTPUT"
-      - name: Check for changes in docker directory
-        id: check_docker_changes
-        run: |
-          git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^docker/' && echo "build_docker=true" >> "$GITHUB_OUTPUT" || echo "build_docker=false" >> "$GITHUB_OUTPUT"
+      # - name: Check for changes in docker directory
+      #   id: check_docker_changes
+      #   run: |
+      #     git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^docker/' && echo "build_docker=true" >> "$GITHUB_OUTPUT" || echo "build_docker=false" >> "$GITHUB_OUTPUT"
   regular_image:
     name: Build & Push Image to DockerHub
     runs-on: ubuntu-latest

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -75,6 +75,7 @@ jobs:
           # tag-custom-only: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        if: ${{ needs.setup.outputs.publish == 'true' }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
@@ -87,9 +88,11 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./docker/datahub-actions/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ needs.setup.outputs.publish == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}
+          cache-from: type=registry,ref=${{ steps.docker_meta.outputs.tags }}
+          cache-to: type=inline
           target: final
           build-args: 'GEM_FURY_TOKEN=${{ secrets.GEMFURY_PULL_TOKEN }}'
   slim_image:
@@ -109,6 +112,7 @@ jobs:
           tags: |
             type=raw,value=${{ needs.setup.outputs.tag }}
       - name: Set up QEMU (slim)
+        if: ${{ needs.setup.outputs.publish == 'true' }}
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx (slim)
         uses: docker/setup-buildx-action@v2
@@ -122,13 +126,23 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./docker/datahub-actions/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ needs.setup.outputs.publish == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           tags: ${{ steps.docker_meta_slim.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}
           target: final
+          load: ${{ needs.setup.outputs.publish != 'true' }}
           build-args: |
             "APP_ENV=prod-slim"
             "GEM_FURY_TOKEN=${{ secrets.GEMFURY_PULL_TOKEN }}"
+      - name: Save Docker image
+        if: needs.setup.outputs.publish != 'true'
+        run: docker save ${{ steps.docker_meta_slim.outputs.tags }} > image.tar
+      - name: Upload artifact
+        if: needs.setup.outputs.publish != 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: docker-image
+          path: image.tar
   # image_scan:
   #   permissions:
   #     contents: read # for actions/checkout to fetch code
@@ -169,20 +183,41 @@ jobs:
     name: '[Monitoring] Scan slim action images for vulnerabilities'
     runs-on: ubuntu-latest
     needs: [setup, slim_image]
-    if: needs.setup.outputs.publish == 'true'
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
         uses: actions/checkout@v4
-      - name: Download image (slim)
+      - name: Set image reference
+        id: set_image_ref
+        run: |
+          if [[ "${{ needs.setup.outputs.publish }}" == "true" ]]; then
+            echo "IMAGE_REF=acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "IMAGE_REF=datahub-actions-slim:local" >> $GITHUB_OUTPUT
+          fi
+      - name: Download artifact (if not publishing)
+        if: needs.setup.outputs.publish != 'true'
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-image
+      - name: Load Docker image (if not publishing)
+        if: needs.setup.outputs.publish != 'true'
+        run: docker load < image.tar
+      - name: Download image (if publishing)
+        if: needs.setup.outputs.publish == 'true'
         uses: ishworkh/docker-image-artifact-download@v1
         with:
-          image: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
+          image: ${{ steps.set_image_ref.outputs.IMAGE_REF }}
+      # - name: Download image (slim)
+      #   uses: ishworkh/docker-image-artifact-download@v1
+      #   with:
+      #     image: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
       - name: Run Trivy vulnerability scanner (slim)
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_OFFLINE_SCAN: true
         with:
-          image-ref: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
+          image-ref: ${{ steps.set_image_ref.outputs.IMAGE_REF }}
+          # image-ref: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -55,16 +55,18 @@ jobs:
         uses: actions/checkout@v3
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v5
         with:
           images: |
             acryldata/datahub-actions
-          tag-custom: ${{ needs.setup.outputs.tag }}
-          tag-custom-only: true
+          tags: |
+            type=raw,value=${{ needs.setup.outputs.tag }}
+          # tag-custom: ${{ needs.setup.outputs.tag }}
+          # tag-custom-only: true
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -78,8 +80,7 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}
           target: final
-          build-args:
-            "GEM_FURY_TOKEN=${{ secrets.GEMFURY_PULL_TOKEN }}"
+          build-args: 'GEM_FURY_TOKEN=${{ secrets.GEMFURY_PULL_TOKEN }}'
   slim_image:
     name: Build & Push Image to DockerHub (slim)
     runs-on: ubuntu-latest
@@ -89,13 +90,13 @@ jobs:
       - name: Check out the repo (slim)
         uses: actions/checkout@v3
       - name: Docker meta (slim)
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        id: docker_meta_slim
+        uses: docker/metadata-action@v5
         with:
           images: |
-            acryldata/datahub-actions
-          tag-custom: ${{ needs.setup.outputs.tag }}
-          tag-custom-only: true
+            acryldata/datahub-actions-slim
+          tags: |
+            type=raw,value=${{ needs.setup.outputs.tag }}
       - name: Set up QEMU (slim)
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx (slim)
@@ -105,14 +106,6 @@ jobs:
         with:
           username: ${{ secrets.ACRYL_DOCKER_USERNAME }}
           password: ${{ secrets.ACRYL_DOCKER_PASSWORD }}
-      - name: Docker meta (slim)
-        id: docker_meta_slim
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          images: |
-            acryldata/datahub-actions-slim
-          tag-custom: ${{ needs.setup.outputs.tag }}
-          tag-custom-only: true
       - name: Build & Push Image (slim)
         uses: docker/build-push-action@v6
         with:
@@ -151,7 +144,7 @@ jobs:
   #         output: 'trivy-results.sarif'
   #         severity: 'CRITICAL,HIGH'
   #         ignore-unfixed: true
-  #         vuln-type: "os,library"          
+  #         vuln-type: "os,library"
   #     - name: Upload Trivy scan results to GitHub Security tab
   #       uses: github/codeql-action/upload-sarif@v2
   #       with:
@@ -161,12 +154,12 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: "[Monitoring] Scan slim action images for vulnerabilities"
+    name: '[Monitoring] Scan slim action images for vulnerabilities'
     runs-on: ubuntu-latest
     needs: [setup, slim_image]
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download image (slim)
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.setup.outputs.publish != 'true' }}
@@ -183,7 +176,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          vuln-type: "os,library"
+          vuln-type: 'os,library'
       - name: Upload Trivy scan results to GitHub Security tab (slim)
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -30,7 +30,7 @@ def get_long_description():
     return description
 
 
-acryl_datahub_min_version = os.environ.get("ACRYL_DATAHUB_MIN_VERSION") or "0.12.1.5"
+acryl_datahub_min_version = os.environ.get("ACRYL_DATAHUB_MIN_VERSION") or "0.13.3.6rc1"
 
 base_requirements = {
     f"acryl-datahub[datahub-kafka]>={acryl_datahub_min_version}",
@@ -86,6 +86,7 @@ plugins: Dict[str, Set[str]] = {
     "snowflake_tag_propagation": {
         f"acryl-datahub[snowflake]>={acryl_datahub_min_version}"
     },
+    "doc_propagation": set(),
     # Transformer Plugins (None yet)
 }
 
@@ -138,6 +139,7 @@ base_dev_requirements = {
             "tag_propagation",
             "term_propagation",
             "snowflake_tag_propagation",
+            "doc_propagation",
         ]
         for dependency in plugins[plugin]
     ),
@@ -158,6 +160,7 @@ full_test_dev_requirements = {
             "tag_propagation",
             "term_propagation",
             "snowflake_tag_propagation",
+            "doc_propagation",
         ]
         for dependency in plugins[plugin]
     ),
@@ -173,6 +176,7 @@ entry_points = {
         "tag_propagation = datahub_actions.plugin.action.tag.tag_propagation_action:TagPropagationAction",
         "term_propagation = datahub_actions.plugin.action.term.term_propagation_action:TermPropagationAction",
         "snowflake_tag_propagation = datahub_actions.plugin.action.snowflake.tag_propagator:SnowflakeTagPropagatorAction",
+        "doc_propagation = datahub_actions.plugin.action.propagation.docs.propagation_action:DocPropagationAction",
     ],
     "datahub_actions.transformer.plugins": [],
     "datahub_actions.source.plugins": [],

--- a/datahub-actions/src/datahub_actions/api/action_graph.py
+++ b/datahub-actions/src/datahub_actions/api/action_graph.py
@@ -186,6 +186,16 @@ query listIngestionSources($input: ListIngestionSourcesInput!, $execution_start:
             return entities
         return []
 
+    def get_upstreams(self, entity_urn: str) -> List[str]:
+        url_frag = f"/relationships?direction=OUTGOING&types=List(DownstreamOf)&urn={urllib.parse.quote(entity_urn)}"
+        url = f"{self.graph._gms_server}{url_frag}"
+        response = self.graph._get_generic(url)
+        if response["count"] > 0:
+            relnships = response["relationships"]
+            entities = [x["entity"] for x in relnships]
+            return entities
+        return []
+
     def get_relationships(
         self, entity_urn: str, direction: str, relationship_types: List[str]
     ) -> List[str]:

--- a/datahub-actions/src/datahub_actions/plugin/action/mcl_utils.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/mcl_utils.py
@@ -1,0 +1,56 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Callable
+
+from datahub.metadata.schema_classes import MetadataChangeLogClass
+
+from datahub_actions.event.event_envelope import EventEnvelope
+from datahub_actions.event.event_registry import METADATA_CHANGE_LOG_EVENT_V1_TYPE
+
+
+class MCLProcessor:
+    """
+    A utility class to register and process MetadataChangeLog events.
+    """
+
+    def __init__(self) -> None:
+        self.entity_aspect_processors: dict[str, dict[str, Callable]] = {}
+        pass
+
+    def is_mcl(self, event: EventEnvelope) -> bool:
+        return event.event_type is METADATA_CHANGE_LOG_EVENT_V1_TYPE
+
+    def register_processor(
+        self, entity_type: str, aspect: str, processor: Callable
+    ) -> None:
+        if entity_type not in self.entity_aspect_processors:
+            self.entity_aspect_processors[entity_type] = {}
+        self.entity_aspect_processors[entity_type][aspect] = processor
+
+    def process(self, event: EventEnvelope) -> Any:
+
+        if isinstance(event.event, MetadataChangeLogClass):
+            entity_type = event.event.entityType
+            aspect = event.event.aspectName
+            if (
+                entity_type in self.entity_aspect_processors
+                and aspect in self.entity_aspect_processors[entity_type]
+            ):
+                return self.entity_aspect_processors[entity_type][aspect](
+                    entity_urn=event.event.entityUrn,
+                    aspect_name=event.event.aspectName,
+                    aspect_value=event.event.aspect,
+                    previous_aspect_value=event.event.previousAspectValue,
+                )

--- a/datahub-actions/src/datahub_actions/plugin/action/propagation/__init__.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/propagation/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/datahub-actions/src/datahub_actions/plugin/action/propagation/docs/__init__.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/propagation/docs/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/datahub-actions/src/datahub_actions/plugin/action/propagation/docs/propagation_action.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/propagation/docs/propagation_action.py
@@ -1,0 +1,645 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import time
+from typing import Any, Iterable, List, Optional
+
+from datahub.configuration.common import ConfigModel
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    AuditStampClass,
+    DocumentationAssociationClass,
+    DocumentationClass,
+    EditableSchemaMetadataClass,
+)
+from datahub.metadata.schema_classes import EntityChangeEventClass as EntityChangeEvent
+from datahub.metadata.schema_classes import (
+    GenericAspectClass,
+    MetadataAttributionClass,
+    MetadataChangeLogClass,
+)
+from datahub.utilities.urns.urn import Urn
+from pydantic import BaseModel, Field, validator
+
+from datahub_actions.action.action import Action
+from datahub_actions.api.action_graph import AcrylDataHubGraph
+from datahub_actions.event.event_envelope import EventEnvelope
+from datahub_actions.pipeline.pipeline_context import PipelineContext
+from datahub_actions.plugin.action.mcl_utils import MCLProcessor
+from datahub_actions.plugin.action.propagation.propagation_utils import (
+    get_unique_siblings,
+)
+from datahub_actions.plugin.action.stats_util import (
+    ActionStageReport,
+    EventProcessingStats,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DocPropagationDirective(BaseModel):
+    propagate: bool = Field(
+        description="Indicates whether the documentation should be propagated."
+    )
+    doc_string: Optional[str] = Field(
+        default=None, description="Documentation string to be propagated."
+    )
+    operation: str = Field(
+        description="Operation to be performed on the documentation. Can be ADD, MODIFY or REMOVE."
+    )
+    entity: str = Field(
+        description="Entity URN from which the documentation is propagated. This will either be the same as the origin or the via entity, depending on the propagation path."
+    )
+    origin: str = Field(
+        description="Origin entity for the documentation. This is the entity that triggered the documentation propagation.",
+    )
+    via: Optional[str] = Field(
+        None,
+        description="Via entity for the documentation. This is the direct entity that the documentation was propagated through.",
+    )
+    actor: Optional[str] = Field(
+        None,
+        description="Actor that triggered the documentation propagation.",
+    )
+
+
+class SourceDetails(BaseModel):
+    origin: Optional[str] = Field(
+        None,
+        description="Origin entity for the documentation. This is the entity that triggered the documentation propagation.",
+    )
+    via: Optional[str] = Field(
+        None,
+        description="Via entity for the documentation. This is the direct entity that the documentation was propagated through.",
+    )
+    propagated: Optional[str] = Field(
+        None,
+        description="Indicates whether the documentation was propagated.",
+    )
+    actor: Optional[str] = Field(
+        None,
+        description="Actor that triggered the documentation propagation.",
+    )
+
+    @validator("propagated", pre=True)
+    def convert_boolean_to_lowercase_string(cls, v: Any) -> Optional[str]:
+        if isinstance(v, bool):
+            return str(v).lower()
+        return v
+
+
+class DocPropagationConfig(ConfigModel):
+    """
+    Configuration model for documentation propagation.
+
+    Attributes:
+        enabled (bool): Indicates whether documentation propagation is enabled or not. Default is True.
+        columns_enabled (bool): Indicates whether column documentation propagation is enabled or not. Default is True.
+        datasets_enabled (bool): Indicates whether dataset level documentation propagation is enabled or not. Default is False.
+
+    Example:
+        config = DocPropagationConfig(enabled=True)
+    """
+
+    enabled: bool = Field(
+        True,
+        description="Indicates whether documentation propagation is enabled or not.",
+        example=True,
+    )
+    columns_enabled: bool = Field(
+        True,
+        description="Indicates whether column documentation propagation is enabled or not.",
+        example=True,
+    )
+    # TODO: Currently this flag does nothing. Datasets are NOT supported for docs propagation.
+    datasets_enabled: bool = Field(
+        False,
+        description="Indicates whether dataset level documentation propagation is enabled or not.",
+        example=False,
+    )
+
+
+def get_field_path(schema_field_urn: str) -> str:
+    urn = Urn.create_from_string(schema_field_urn)
+    return urn.get_entity_id()[1]
+
+
+def get_field_doc_from_dataset(
+    graph: AcrylDataHubGraph, dataset_urn: str, schema_field_urn: str
+) -> Optional[str]:
+    editableSchemaMetadata = graph.graph.get_aspect(
+        dataset_urn, EditableSchemaMetadataClass
+    )
+    if editableSchemaMetadata is not None:
+        if editableSchemaMetadata.editableSchemaFieldInfo is not None:
+            field_info = [
+                x
+                for x in editableSchemaMetadata.editableSchemaFieldInfo
+                if x.fieldPath == get_field_path(schema_field_urn)
+            ]
+            if field_info:
+                return field_info[0].description
+    return None
+
+
+ECE_EVENT_TYPE = "EntityChangeEvent_v1"
+
+
+class DocPropagationAction(Action):
+    def __init__(self, config: DocPropagationConfig, ctx: PipelineContext):
+        super().__init__()
+        self.action_urn: str
+        if not ctx.pipeline_name.startswith("urn:li:dataHubAction"):
+            self.action_urn = f"urn:li:dataHubAction:{ctx.pipeline_name}"
+        else:
+            self.action_urn = ctx.pipeline_name
+
+        self.config: DocPropagationConfig = config
+        self.last_config_refresh: float = 0
+        self.ctx = ctx
+        self.mcl_processor = MCLProcessor()
+        self.actor_urn = "urn:li:corpuser:__datahub_system"
+
+        self.mcl_processor.register_processor(
+            "schemaField",
+            "documentation",
+            self.process_schema_field_documentation,
+        )
+        self.refresh_config()
+        self._stats = ActionStageReport()
+        self._stats.start()
+
+    def name(self) -> str:
+        return "DocPropagator"
+
+    @classmethod
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> "Action":
+        action_config = DocPropagationConfig.parse_obj(config_dict or {})
+        logger.info(f"Doc Propagation Config action configured with {action_config}")
+        return cls(action_config, ctx)
+
+    def process_schema_field_documentation(
+        self,
+        entity_urn: str,
+        aspect_name: str,
+        aspect_value: GenericAspectClass,
+        previous_aspect_value: Optional[GenericAspectClass],
+    ) -> Optional[DocPropagationDirective]:
+        if aspect_name == "documentation":
+            logger.debug("Processing 'documentation' MCL")
+            if self.config.columns_enabled:
+                current_docs = DocumentationClass.from_obj(
+                    json.loads(aspect_value.value)
+                )
+                old_docs = (
+                    None
+                    if previous_aspect_value is None
+                    else DocumentationClass.from_obj(
+                        json.loads(previous_aspect_value.value)
+                    )
+                )
+                if current_docs.documentations:
+                    # we assume that the first documentation is the primary one
+                    # we can change this later
+                    current_documentation_instance = current_docs.documentations[0]
+                    source_details = (
+                        (current_documentation_instance.attribution.sourceDetail)
+                        if current_documentation_instance.attribution
+                        else {}
+                    )
+                    origin_entity = source_details.get("origin")
+                    if old_docs is None or not old_docs.documentations:
+                        return DocPropagationDirective(
+                            propagate=True,
+                            doc_string=current_documentation_instance.documentation,
+                            operation="ADD",
+                            entity=entity_urn,
+                            origin=origin_entity,
+                            via=entity_urn,
+                            actor=self.actor_urn,
+                        )
+                    else:
+                        if (
+                            current_docs.documentations[0].documentation
+                            != old_docs.documentations[0].documentation
+                        ):
+                            return DocPropagationDirective(
+                                propagate=True,
+                                doc_string=current_documentation_instance.documentation,
+                                operation="MODIFY",
+                                entity=entity_urn,
+                                origin=origin_entity,
+                                via=entity_urn,
+                                actor=self.actor_urn,
+                            )
+        return None
+
+    def should_propagate(
+        self, event: EventEnvelope
+    ) -> Optional[DocPropagationDirective]:
+
+        if self.mcl_processor.is_mcl(event):
+            return self.mcl_processor.process(event)
+        if event.event_type == "EntityChangeEvent_v1":
+            assert isinstance(event.event, EntityChangeEvent)
+            # logger.info(f"Received event {event}")
+            assert self.ctx.graph is not None
+            semantic_event = event.event
+            if (
+                semantic_event.category == "DOCUMENTATION"
+                and self.config is not None
+                and self.config.enabled
+            ):
+                logger.debug("Processing EntityChangeEvent Documentation Change")
+                if self.config.columns_enabled and (
+                    semantic_event.entityType == "schemaField"
+                ):
+                    if semantic_event.parameters:
+                        parameters = semantic_event.parameters
+                    else:
+                        parameters = semantic_event._inner_dict.get(
+                            "__parameters_json", {}
+                        )
+                    doc_string = parameters.get("description")
+                    origin = parameters.get("origin")
+                    origin = origin or semantic_event.entityUrn
+                    via = (
+                        semantic_event.entityUrn
+                        if origin != semantic_event.entityUrn
+                        else None
+                    )
+                    logger.debug(f"Origin: {origin}")
+                    logger.debug(f"Via: {via}")
+                    logger.debug(f"Doc string: {doc_string}")
+                    logger.debug(f"Semantic event {semantic_event}")
+                    if doc_string:
+                        return DocPropagationDirective(
+                            propagate=True,
+                            doc_string=doc_string,
+                            operation=semantic_event.operation,
+                            entity=semantic_event.entityUrn,
+                            origin=origin,
+                            via=via,  # if origin is set, then via is the entity itself
+                            actor=(
+                                semantic_event.auditStamp.actor
+                                if semantic_event.auditStamp
+                                else self.actor_urn
+                            ),
+                        )
+        return None
+
+    def modify_docs_on_columns(
+        self,
+        graph: AcrylDataHubGraph,
+        operation: str,
+        schema_field_urn: str,
+        dataset_urn: str,
+        field_doc: Optional[str],
+        context: SourceDetails,
+    ) -> Optional[MetadataChangeProposalWrapper]:
+        if context.origin == schema_field_urn:
+            # No need to propagate to self
+            return None
+
+        if not dataset_urn.startswith("urn:li:dataset"):
+            logger.error(
+                f"Invalid dataset urn {dataset_urn}. Must start with urn:li:dataset"
+            )
+            return None
+
+        auditStamp = AuditStampClass(
+            time=int(time.time() * 1000.0), actor=self.actor_urn
+        )
+
+        source_details = context.dict(exclude_none=True)
+        attribution: MetadataAttributionClass = MetadataAttributionClass(
+            source=self.action_urn,
+            time=auditStamp.time,
+            actor=self.actor_urn,
+            sourceDetail=source_details,
+        )
+        documentations = graph.graph.get_aspect(schema_field_urn, DocumentationClass)
+        if documentations:
+            mutation_needed = False
+            action_sourced = False
+            # we check if there are any existing documentations generated by
+            # this action, if so, we update them
+            # otherwise, we add a new documentation entry sourced by this action
+            for doc_association in documentations.documentations:
+                if doc_association.attribution and doc_association.attribution.source:
+                    if doc_association.attribution.source == self.action_urn:
+                        action_sourced = True
+                        if doc_association.documentation != field_doc:
+                            mutation_needed = True
+                            if operation == "ADD" or operation == "MODIFY":
+                                doc_association.documentation = field_doc or ""
+                                doc_association.attribution = attribution
+                            elif operation == "REMOVE":
+                                # TODO : should we remove the documentation or just set it to empty string?
+                                # Ideally we remove it
+                                doc_association.documentation = ""
+                                doc_association.attribution = attribution
+            if not action_sourced:
+                documentations.documentations.append(
+                    DocumentationAssociationClass(
+                        documentation=field_doc or "",
+                        attribution=attribution,
+                    )
+                )
+                mutation_needed = True
+        else:
+            # no docs found, create a new one
+            # we don't check editableSchemaMetadata because our goal is to
+            # propagate documentation to downstream entities
+            # UI will handle resolving priorities and conflicts
+            documentations = DocumentationClass(
+                documentations=[
+                    DocumentationAssociationClass(
+                        documentation=field_doc or "",
+                        attribution=attribution,
+                    )
+                ]
+            )
+            mutation_needed = True
+
+        if mutation_needed:
+            logger.debug(
+                f"Will emit documentation change proposal for {schema_field_urn} with {field_doc}"
+            )
+            return MetadataChangeProposalWrapper(
+                entityUrn=schema_field_urn,
+                aspect=documentations,
+            )
+        return None
+
+    def refresh_config(self, event: Optional[EventEnvelope] = None) -> None:
+        """
+        Fetches important configuration flags from the global settings entity to
+        override client-side settings.
+        If not found, it will use the client-side values.
+        """
+        now = time.time()
+        try:
+            if now - self.last_config_refresh > 60 or self._is_settings_change(event):
+                assert self.ctx.graph
+                entity_dict = self.ctx.graph.graph.get_entity_raw(
+                    "urn:li:globalSettings:0", ["globalSettingsInfo"]
+                )
+                if entity_dict:
+                    global_settings = entity_dict.get("aspects", {}).get(
+                        "globalSettingsInfo"
+                    )
+                    if global_settings:
+                        doc_propagation_config = global_settings.get("value", {}).get(
+                            "docPropagation"
+                        )
+                        if doc_propagation_config:
+                            if doc_propagation_config.get("enabled") is not None:
+                                logger.info(
+                                    "Overwriting the asset-level config using globalSettings"
+                                )
+                                self.config.enabled = doc_propagation_config.get(
+                                    "enabled"
+                                )
+                            if (
+                                doc_propagation_config.get("columnPropagationEnabled")
+                                is not None
+                            ):
+                                logger.info(
+                                    "Overwriting the column-level config using globalSettings"
+                                )
+                                self.config.columns_enabled = (
+                                    doc_propagation_config.get(
+                                        "columnPropagationEnabled"
+                                    )
+                                )
+        except Exception:
+            # We don't want to fail the pipeline if we can't fetch the config
+            logger.warning(
+                "Error fetching global settings for doc propagation. Will try again in 1 minute.",
+                exc_info=True,
+            )
+        self.last_config_refresh = now
+
+    def _is_settings_change(self, event: Optional[EventEnvelope]) -> bool:
+        if event and isinstance(event.event, MetadataChangeLogClass):
+            entity_type = event.event.entityType
+            if entity_type == "globalSettings":
+                return True
+        return False
+
+    def get_upstreams(self, graph: AcrylDataHubGraph, entity_urn: str) -> List[str]:
+        """
+        Fetch the upstreams for an dataset or schema field.
+        Note that this DOES NOT support DataJob upstreams, or any intermediate nodes.
+        """
+        import urllib.parse
+
+        url_frag = f"/relationships?direction=OUTGOING&types=List(DownstreamOf)&urn={urllib.parse.quote(entity_urn)}"
+        url = f"{graph.graph._gms_server}{url_frag}"
+        response = graph.graph._get_generic(url)
+        if response["count"] > 0:
+            relnships = response["relationships"]
+            entities = [x["entity"] for x in relnships]
+            return entities
+        return []
+
+    def _only_one_upstream_field(
+        self,
+        graph: AcrylDataHubGraph,
+        downstream_field: str,
+        upstream_field: str,
+    ) -> bool:
+        """
+        Check if there is only one upstream field for the downstream field. If upstream_field is provided,
+        it will also check if the upstream field is the only upstream
+
+        TODO: We should cache upstreams because we make this fetch upstreams call FOR EVERY downstream that must be propagated to.
+        """
+        upstreams = (
+            graph.get_upstreams(entity_urn=downstream_field)
+            if hasattr(graph, "get_upstreams")
+            else self.get_upstreams(graph, downstream_field)
+        )
+        # Use a set here in case there are duplicated upstream edges
+        upstream_fields = list(
+            {x for x in upstreams if x.startswith("urn:li:schemaField")}
+        )
+
+        # If we found no upstreams for the downstream field, simply skip.
+        if not upstream_fields:
+            logger.warning(
+                f"No upstream fields found. Skipping propagation to downstream {downstream_field}"
+            )
+            return False
+
+        # Convert the set to a list to access by index
+        result = len(upstream_fields) == 1 and upstream_fields[0] == upstream_field
+        if not result:
+            logger.warning(
+                f"Failed check for single upstream: Found upstream fields {upstream_fields} for downstream {downstream_field}. Expecting only one upstream field: {upstream_field}"
+            )
+        return result
+
+    def act(self, event: EventEnvelope) -> None:
+        assert self.ctx.graph
+        for mcp in self.act_async(event):
+            self.ctx.graph.graph.emit(mcp)
+
+    def act_async(
+        self, event: EventEnvelope
+    ) -> Iterable[MetadataChangeProposalWrapper]:
+        """
+        Process the event asynchronously and return the change proposals
+        """
+        self.refresh_config(event)
+        if not self.config.enabled or not self.config.columns_enabled:
+            logger.warning("Doc propagation is disabled. Skipping event")
+            return
+        else:
+            logger.debug(f"Processing event {event}")
+
+        if not self._stats.event_processing_stats:
+            self._stats.event_processing_stats = EventProcessingStats()
+
+        stats = self._stats.event_processing_stats
+        stats.start(event)
+
+        try:
+            doc_propagation_directive = self.should_propagate(event)
+            logger.debug(
+                f"Doc propagation directive for {event}: {doc_propagation_directive}"
+            )
+
+            if (
+                doc_propagation_directive is not None
+                and doc_propagation_directive.propagate
+            ):
+                self._stats.increment_assets_processed(doc_propagation_directive.entity)
+                context = SourceDetails(
+                    origin=doc_propagation_directive.origin,
+                    via=doc_propagation_directive.via,
+                    propagated=True,
+                    actor=doc_propagation_directive.actor,
+                )
+                assert self.ctx.graph
+
+                # TODO: Put each mechanism behind a config flag to be controlled externally.
+
+                # Step 1: Propagate to downstream entities
+                yield from self._propagate_to_downstreams(
+                    doc_propagation_directive, context
+                )
+
+                # Step 2: Propagate to sibling entities
+                yield from self._propagate_to_siblings(
+                    doc_propagation_directive, context
+                )
+
+            stats.end(event, success=True)
+
+        except Exception:
+            logger.error(f"Error processing event {event}:", exc_info=True)
+            stats.end(event, success=False)
+
+    def _propagate_to_downstreams(
+        self, doc_propagation_directive: DocPropagationDirective, context: SourceDetails
+    ) -> Iterable[MetadataChangeProposalWrapper]:
+        """
+        Propagate the documentation to downstream entities.
+        """
+        assert self.ctx.graph
+        downstreams = self.ctx.graph.get_downstreams(
+            entity_urn=doc_propagation_directive.entity
+        )
+        logger.debug(
+            f"Downstreams: {downstreams} for {doc_propagation_directive.entity}"
+        )
+        entity_urn = doc_propagation_directive.entity
+
+        if entity_urn.startswith("urn:li:schemaField"):
+            downstream_fields = {
+                x for x in downstreams if x.startswith("urn:li:schemaField")
+            }
+            for field in downstream_fields:
+                schema_field_urn = Urn.create_from_string(field)
+                parent_urn = schema_field_urn.get_entity_id()[0]
+                field_path = schema_field_urn.get_entity_id()[1]
+
+                logger.debug(
+                    f"Will {doc_propagation_directive.operation} documentation {doc_propagation_directive.doc_string} for {field_path} on {parent_urn}"
+                )
+
+                if parent_urn.startswith("urn:li:dataset"):
+                    if self._only_one_upstream_field(
+                        self.ctx.graph,
+                        downstream_field=str(schema_field_urn),
+                        upstream_field=entity_urn,
+                    ):
+                        maybe_mcp = self.modify_docs_on_columns(
+                            self.ctx.graph,
+                            doc_propagation_directive.operation,
+                            field,
+                            parent_urn,
+                            field_doc=doc_propagation_directive.doc_string,
+                            context=context,
+                        )
+                        if maybe_mcp:
+                            yield maybe_mcp
+
+                elif parent_urn.startswith("urn:li:chart"):
+                    logger.warning(
+                        "Charts are expected to have fields that are dataset schema fields. Skipping for now..."
+                    )
+
+                self._stats.increment_assets_impacted(field)
+
+        elif entity_urn.startswith("urn:li:dataset"):
+            logger.debug(
+                "Dataset level documentation propagation is not yet supported!"
+            )
+
+    def _propagate_to_siblings(
+        self, doc_propagation_directive: DocPropagationDirective, context: SourceDetails
+    ) -> Iterable[MetadataChangeProposalWrapper]:
+        """
+        Propagate the documentation to sibling entities.
+        """
+        assert self.ctx.graph
+        entity_urn = doc_propagation_directive.entity
+        siblings = get_unique_siblings(self.ctx.graph, entity_urn)
+
+        logger.debug(f"Siblings: {siblings} for {doc_propagation_directive.entity}")
+
+        for sibling in siblings:
+            if entity_urn.startswith("urn:li:schemaField") and sibling.startswith(
+                "urn:li:schemaField"
+            ):
+                parent_urn = Urn.create_from_string(sibling).get_entity_id()[0]
+                self._stats.increment_assets_impacted(sibling)
+                maybe_mcp = self.modify_docs_on_columns(
+                    self.ctx.graph,
+                    doc_propagation_directive.operation,
+                    schema_field_urn=sibling,
+                    dataset_urn=parent_urn,
+                    field_doc=doc_propagation_directive.doc_string,
+                    context=context,
+                )
+                if maybe_mcp:
+                    yield maybe_mcp
+
+    def close(self) -> None:
+        return super().close()

--- a/datahub-actions/src/datahub_actions/plugin/action/propagation/propagation_utils.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/propagation/propagation_utils.py
@@ -1,0 +1,173 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import time
+from abc import abstractmethod
+from enum import Enum
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import datahub.metadata.schema_classes as models
+from datahub.emitter.mce_builder import make_schema_field_urn
+from datahub.ingestion.graph.client import SearchFilterRule
+from datahub.metadata.schema_classes import MetadataAttributionClass
+from datahub.utilities.urns.urn import Urn
+from pydantic.fields import Field
+from pydantic.main import BaseModel
+
+from datahub_actions.api.action_graph import AcrylDataHubGraph
+
+SYSTEM_ACTOR = "urn:li:corpuser:__datahub_system"
+
+
+class RelationshipType(Enum):
+    LINEAGE = "lineage"  # signifies all types of lineage
+    HIERARCHY = "hierarchy"  # signifies all types of hierarchy
+
+
+class DirectionType(Enum):
+    UP = "up"  # signifies upstream or parent (depending on relationship type)
+    DOWN = "down"  # signifies downstream or child (depending on relationship type)
+    ALL = "all"  # signifies all directions
+
+
+class PropagationDirective(BaseModel):
+    propagate: bool
+    operation: str
+    relationship: RelationshipType = RelationshipType.LINEAGE
+    direction: DirectionType = DirectionType.UP
+    entity: str = Field(
+        description="Entity that currently triggered the propagation directive",
+    )
+    origin: str = Field(
+        description="Origin entity for the association. This is the entity that triggered the propagation.",
+    )
+    via: Optional[str] = Field(
+        None,
+        description="Via entity for the association. This is the direct entity that the propagation came through.",
+    )
+    actor: Optional[str] = Field(
+        None,
+        description="Actor that triggered the propagation through the original association.",
+    )
+
+
+def get_attribution_and_context_from_directive(
+    action_urn: str,
+    propagation_directive: PropagationDirective,
+    actor: str = SYSTEM_ACTOR,
+    time: int = int(time.time() * 1000.0),
+) -> Tuple[MetadataAttributionClass, str]:
+    """
+    Given a propagation directive, return the attribution and context for
+    the directive.
+    Attribution is the official way to track the source of metadata in
+    DataHub.
+    Context is the older way to track the source of metadata in DataHub.
+    We populate both to ensure compatibility with older versions of DataHub.
+    """
+    source_detail: dict[str, str] = {
+        "origin": propagation_directive.origin,
+        "propagated": "true",
+    }
+    if propagation_directive.actor:
+        source_detail["actor"] = propagation_directive.actor
+    else:
+        source_detail["actor"] = actor
+    if propagation_directive.via:
+        source_detail["via"] = propagation_directive.via
+    context_dict: dict[str, str] = {}
+    context_dict.update(source_detail)
+    return (
+        MetadataAttributionClass(
+            time=time,
+            actor=actor,
+            source=action_urn,
+            sourceDetail=source_detail,
+        ),
+        json.dumps(context_dict),
+    )
+
+
+class SelectedAsset(BaseModel):
+    """
+    A selected asset is a data structure that represents an asset that has been
+    selected for processing by a propagator.
+    """
+
+    urn: str  # URN of the asset that has been selected
+    target_entity_type: str  # entity type that is being targeted by the propagator. e.g. schemaField even if asset is of type dataset
+
+
+class ComposablePropagator:
+
+    @abstractmethod
+    def asset_filters(self) -> Dict[str, Dict[str, List[SearchFilterRule]]]:
+        """
+        Returns a dictionary of asset filters that are used to filter the assets
+        based on the configuration of the action.
+        """
+        pass
+
+    @abstractmethod
+    def process_one_asset(
+        self, asset: SelectedAsset, operation: str
+    ) -> Iterable[PropagationDirective]:
+        """
+        Given an asset, returns a list of propagation directives
+
+        :param asset_urn: URN of the asset
+        :param target_entity_type: The entity type of the target entity (Note:
+            this can be different from the entity type of the asset. e.g. we
+            might process a dataset while the target entity_type is a column
+            (schemaField))
+        :param operation: The operation that triggered the propagation (ADD /
+            REMOVE)
+        :return: A list of PropagationDirective objects
+        """
+        pass
+
+
+def get_unique_siblings(graph: AcrylDataHubGraph, entity_urn: str) -> list[str]:
+    """
+    Get unique siblings for the entity urn
+    """
+
+    if entity_urn.startswith("urn:li:schemaField"):
+        parent_urn = Urn.create_from_string(entity_urn).get_entity_id()[0]
+        entity_field_path = Urn.create_from_string(entity_urn).get_entity_id()[1]
+        # Does my parent have siblings?
+        siblings: Optional[models.SiblingsClass] = graph.graph.get_aspect(
+            parent_urn,
+            models.SiblingsClass,
+        )
+        if siblings and siblings.siblings:
+            other_siblings = [x for x in siblings.siblings if x != parent_urn]
+            if len(other_siblings) == 1:
+                target_sibling = other_siblings[0]
+                # now we need to find the schema field in this sibling that
+                # matches us
+                if target_sibling.startswith("urn:li:dataset"):
+                    schema_fields = graph.graph.get_aspect(
+                        target_sibling, models.SchemaMetadataClass
+                    )
+                    if schema_fields:
+                        for schema_field in schema_fields.fields:
+                            if schema_field.fieldPath == entity_field_path:
+                                # we found the sibling field
+                                schema_field_urn = make_schema_field_urn(
+                                    target_sibling, schema_field.fieldPath
+                                )
+                                return [schema_field_urn]
+    return []

--- a/datahub-actions/src/datahub_actions/plugin/action/stats_util.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/stats_util.py
@@ -1,0 +1,204 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import json
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, Optional
+
+import pydantic
+from datahub.ingestion.api.report import Report, SupportsAsObj
+from pydantic import BaseModel
+
+from datahub_actions.action.action import Action
+from datahub_actions.event.event_envelope import EventEnvelope
+from datahub_actions.event.event_registry import (
+    ENTITY_CHANGE_EVENT_V1_TYPE,
+    METADATA_CHANGE_LOG_EVENT_V1_TYPE,
+    EntityChangeEvent,
+    MetadataChangeLogEvent,
+)
+from datahub_actions.pipeline.pipeline_context import PipelineContext
+
+
+class EventProcessingStats(BaseModel):
+    """
+    A class to represent the event-oriented processing stats for a pipeline.
+    Note: Might be merged into ActionStats in the future.
+    """
+
+    last_seen_event_time: Optional[str] = pydantic.Field(
+        None, description="The event time of the last event we processed"
+    )
+    last_event_processed_time: Optional[str] = pydantic.Field(
+        None, description="The time at which we processed the last event"
+    )
+    last_seen_event_time_success: Optional[str] = pydantic.Field(
+        None, description="The event time of the last event we processed successfully"
+    )
+    last_event_processed_time_success: Optional[str] = pydantic.Field(
+        None, description="The time at which we processed the last event successfully"
+    )
+    last_seen_event_time_failure: Optional[str] = pydantic.Field(
+        None, description="The event time of the last event we processed unsuccessfully"
+    )
+    last_event_processed_time_failure: Optional[str] = pydantic.Field(
+        None, description="The time at which we processed the last event unsuccessfully"
+    )
+
+    @classmethod
+    def _get_event_time(cls, event: EventEnvelope) -> Optional[str]:
+        """
+        Get the event time from the event.
+        """
+        if event.event_type == ENTITY_CHANGE_EVENT_V1_TYPE:
+            if isinstance(event.event, EntityChangeEvent):
+                return (
+                    datetime.fromtimestamp(
+                        event.event.auditStamp.time / 1000.0, tz=timezone.utc
+                    ).isoformat()
+                    if event.event.auditStamp
+                    else None
+                )
+        elif event.event_type == METADATA_CHANGE_LOG_EVENT_V1_TYPE:
+            if isinstance(event.event, MetadataChangeLogEvent):
+                return (
+                    datetime.fromtimestamp(
+                        event.event.auditHeader.time / 1000.0, tz=timezone.utc
+                    ).isoformat()
+                    if event.event.auditHeader
+                    else None
+                )
+        return None
+
+    def start(self, event: EventEnvelope) -> None:
+        """
+        Update the stats based on the event.
+        """
+        self.last_event_processed_time = datetime.now(tz=timezone.utc).isoformat()
+        self.last_seen_event_time = self._get_event_time(event)
+
+    def end(self, event: EventEnvelope, success: bool) -> None:
+        """
+        Update the stats based on the event.
+        """
+
+        if success:
+            self.last_seen_event_time_success = (
+                self._get_event_time(event) or self.last_seen_event_time_success
+            )
+            self.last_event_processed_time_success = datetime.now(
+                timezone.utc
+            ).isoformat()
+        else:
+            self.last_seen_event_time_failure = (
+                self._get_event_time(event) or self.last_seen_event_time_failure
+            )
+            self.last_event_processed_time_failure = datetime.now(
+                timezone.utc
+            ).isoformat()
+
+    def __str__(self) -> str:
+        return json.dumps(self.dict(), indent=2)
+
+
+class StageStatus(str, Enum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+    RUNNING = "running"
+    STOPPED = "stopped"
+
+
+class ActionStageReport(BaseModel):
+    # All stats here are only for the current run of the current stage.
+
+    # Attributes that should be aggregated across runs should be prefixed with "total_".
+    # Only ints can be aggregated.
+
+    start_time: int = 0
+
+    end_time: int = 0
+
+    total_assets_to_process: int = -1  # -1 if unknown
+
+    total_assets_processed: int = 0
+
+    total_actions_executed: int = 0
+
+    total_assets_impacted: int = 0
+
+    event_processing_stats: Optional[EventProcessingStats] = None
+
+    status: Optional[StageStatus] = None
+
+    def start(self) -> None:
+        self.start_time = int(datetime.now().timestamp() * 1000)
+        self.status = StageStatus.RUNNING
+
+    def end(self, success: bool) -> None:
+        self.end_time = int(datetime.now().timestamp() * 1000)
+        self.status = StageStatus.SUCCESS if success else StageStatus.FAILURE
+
+    def increment_assets_processed(self, asset: str) -> None:
+        # TODO: If we want to track unique assets, use a counting set.
+        # For now, just increment
+        self.total_assets_processed += 1
+
+    def increment_assets_impacted(self, asset: str) -> None:
+        # TODO: If we want to track unique assets, use a counting set.
+        # For now, just increment
+        self.total_assets_impacted += 1
+
+    def as_obj(self) -> dict:
+        return Report.to_pure_python_obj(self)
+
+    def aggregatable_stats(self) -> Dict[str, int]:
+        all_items = self.dict()
+
+        stats = {k: v for k, v in all_items.items() if k.startswith("total_")}
+
+        # If total_assets_to_process is unknown, don't include it.
+        if self.total_assets_to_process == -1:
+            stats.pop("total_assets_to_process")
+
+        # Add a few additional special cases of aggregatable stats.
+        if self.event_processing_stats:
+            for key, value in self.event_processing_stats.dict().items():
+                if value is not None:
+                    stats[f"event_processing_stats.{key}"] = str(value)
+
+        return stats
+
+
+class ReportingAction(Action, abc.ABC):
+    def __init__(self, ctx: PipelineContext):
+        super().__init__()
+        self.ctx = ctx
+
+        self.action_urn: str
+        if "urn:li:dataHubAction:" in ctx.pipeline_name:
+            # The pipeline name might get a prefix before the urn:li:... part.
+            # We need to remove that prefix to get the urn:li:dataHubAction part.
+            action_urn_part = ctx.pipeline_name.split("urn:li:dataHubAction:")[1]
+            self.action_urn = f"urn:li:dataHubAction:{action_urn_part}"
+        else:
+            self.action_urn = f"urn:li:dataHubAction:{ctx.pipeline_name}"
+
+    @abc.abstractmethod
+    def get_report(self) -> ActionStageReport:
+        pass
+
+
+assert isinstance(ActionStageReport(), SupportsAsObj)

--- a/datahub-actions/tests/unit/test_helpers.py
+++ b/datahub-actions/tests/unit/test_helpers.py
@@ -41,18 +41,11 @@ from datahub_actions.transform.transformer_registry import transformer_registry
 # Mocked Metadata Change Log representing a Domain change for a Dataset.
 metadata_change_log_event = MetadataChangeLogEvent.from_class(
     MetadataChangeLogClass(
-        "dataset",
-        "UPSERT",
-        None,
-        "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
-        None,
-        "domains",
-        None,
-        None,
-        None,
-        None,
-        None,
-        AuditStampClass(0, "urn:li:corpuser:datahub"),
+        entityType="dataset",
+        changeType="UPSERT",
+        entityUrn="urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+        aspectName="domains",
+        created=AuditStampClass(0, "urn:li:corpuser:datahub"),
     )
 )
 

--- a/docker/config/doc_propagation_action.yaml
+++ b/docker/config/doc_propagation_action.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: ${DATAHUB_ACTIONS_DOC_PROPAGATION_CONSUMER_GROUP_ID:-datahub_doc_propagation_action}
+enabled: ${DATAHUB_ACTIONS_DOC_PROPAGATION_ENABLED:-true}
+source:
+  type: 'kafka'
+  config:
+    connection:
+      bootstrap: ${KAFKA_BOOTSTRAP_SERVER:-localhost:9092}
+      schema_registry_url: ${SCHEMA_REGISTRY_URL:-http://localhost:8081}
+    topic_routes:
+      mcl: ${METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME:-MetadataChangeLog_Versioned_v1}
+      pe: ${PLATFORM_EVENT_TOPIC_NAME:-PlatformEvent_v1}
+action:
+  type: doc_propagation
+  config:
+    # Action-specific configs (map)
+    columns_enabled: ${DATAHUB_ACTIONS_DOC_PROPAGATION_COLUMNS_ENABLED:-true}
+
+datahub:
+  server: 'http://${DATAHUB_GMS_HOST:-localhost}:${DATAHUB_GMS_PORT:-8080}'
+  extra_headers:
+    Authorization: 'Basic ${DATAHUB_SYSTEM_CLIENT_ID:-__datahub_system}:${DATAHUB_SYSTEM_CLIENT_SECRET:-JohnSnowKnowsNothing}'

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,3 +14,4 @@
 * limitations under the License.
 */
 include 'datahub-actions'
+include 'smoke-test'

--- a/smoke-test/build.gradle
+++ b/smoke-test/build.gradle
@@ -1,0 +1,45 @@
+
+ext {
+  python_executable = 'python3'
+  venv_name = 'venv'
+}
+
+
+task installDev(type: Exec) {
+    inputs.file file('pyproject.toml')
+    inputs.file file('requirements.txt')
+    outputs.file("${venv_name}/.build_install_dev_sentinel")
+    commandLine 'bash', '-c',
+        "set -x && " +
+        "${python_executable} -m venv ${venv_name} && " +
+        "${venv_name}/bin/python -m pip install --upgrade pip uv wheel setuptools && " +
+        "set +x && source ${venv_name}/bin/activate && set -x && " +
+        "uv pip install -r requirements.txt && " +
+        "touch ${venv_name}/.build_install_dev_sentinel"
+}
+
+task pythonLint(type: Exec, dependsOn: installDev) {
+    commandLine 'bash', '-c',
+        "source ${venv_name}/bin/activate && set -x && " +
+        "black --check --diff tests/ && " +
+        "isort --check --diff tests/ && " +
+        "ruff --statistics tests/ && " +
+        "mypy tests/"
+}
+task pythonLintFix(type: Exec, dependsOn: installDev) {
+    commandLine 'bash', '-c',
+        "source ${venv_name}/bin/activate && set -x && " +
+        "black tests/ && " +
+        "isort tests/ && " +
+        "ruff --fix tests/ && " +
+        "mypy tests/"
+}
+
+
+task lint {
+    dependsOn pythonLint
+}
+
+task lintFix {
+    dependsOn pythonLintFix
+}

--- a/smoke-test/pyproject.toml
+++ b/smoke-test/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "smoke-test"
+version = "0.0.0"
+description = ""
+authors = [
+	{ name="Acryl Data", email="eng@acryl.io" },
+]
+requires-python = ">=3.9"
+
+
+[tool.black]
+extend-exclude = '''
+# A regex preceded with ^/ will apply only to files and directories
+# in the root of the project.
+tmp
+venv
+'''
+include = '\.pyi?$'
+target-version = ['py310']
+
+[tool.isort]
+profile = 'black'
+
+[tool.ruff]
+ignore = [
+	'E501', # Ignore line length, since black handles that.
+	'D203', # Ignore 1 blank line required before class docstring.
+]
+
+[tool.mypy]
+exclude = "^(venv/|build/|dist/)"
+ignore_missing_imports = true
+namespace_packages = false
+check_untyped_defs = true
+disallow_untyped_decorators = true
+warn_unused_configs = true
+# eventually we'd like to enable these
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+
+[tool.pyright]
+extraPaths = ['tests']

--- a/smoke-test/pytest.ini
+++ b/smoke-test/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    read_only: marks tests as read only (deselect with '-m "not read_only"')

--- a/smoke-test/requests_wrapper/__init__.py
+++ b/smoke-test/requests_wrapper/__init__.py
@@ -1,0 +1,4 @@
+from .utils_requests_wrapper import CustomSession as Session
+from .utils_requests_wrapper import get, post
+from .constants import *
+from requests import exceptions

--- a/smoke-test/requests_wrapper/utils_requests_wrapper.py
+++ b/smoke-test/requests_wrapper/utils_requests_wrapper.py
@@ -1,0 +1,27 @@
+import requests
+from tests.consistency_utils import wait_for_writes_to_sync
+
+
+class CustomSession(requests.Session):
+    """
+    Create a custom session to add consistency delay on writes
+    """
+
+    def post(self, *args, **kwargs):
+        response = super(CustomSession, self).post(*args, **kwargs)
+        if "/logIn" not in args[0]:
+            print("sleeping.")
+            wait_for_writes_to_sync()
+        return response
+
+
+def post(*args, **kwargs):
+    response = requests.post(*args, **kwargs)
+    if "/logIn" not in args[0]:
+        print("sleeping.")
+        wait_for_writes_to_sync()
+    return response
+
+
+def get(*args, **kwargs):
+    return requests.get(*args, **kwargs)

--- a/smoke-test/requests_wrapper/utils_requests_wrapper.py
+++ b/smoke-test/requests_wrapper/utils_requests_wrapper.py
@@ -1,3 +1,4 @@
+# Copied largely without modification from datahub-project/datahub/smoke-test/requests_wrapper
 import requests
 from tests.consistency_utils import wait_for_writes_to_sync
 

--- a/smoke-test/requirements.txt
+++ b/smoke-test/requirements.txt
@@ -1,0 +1,22 @@
+pytest>=6.2
+pytest-dependency>=0.5.1
+psutil
+tenacity
+slack-sdk==3.18.1
+aiohttp
+joblib
+pytest-xdist
+networkx
+# libaries for linting below this
+black==23.7.0
+isort==5.12.0
+mypy==1.5.1
+ruff==0.0.287
+# stub version are copied from metadata-ingestion/setup.py and that should be the source of truth
+types-requests>=2.28.11.6,<=2.31.0.3
+types-PyYAML
+# https://github.com/docker/docker-py/issues/3256
+requests<=2.31.0
+# Missing numpy requirement in 8.0.0
+deepdiff!=8.0.0
+acryl-datahub

--- a/smoke-test/run-quickstart.sh
+++ b/smoke-test/run-quickstart.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euxo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
+
+../gradlew :smoke-test:installDev
+source venv/bin/activate
+
+mkdir -p ~/.datahub/plugins/frontend/auth/
+echo "test_user:test_pass" >> ~/.datahub/plugins/frontend/auth/user.props
+
+echo "DATAHUB_ACTIONS_VERSION = $DATAHUB_ACTIONS_VERSION"
+
+DATAHUB_TELEMETRY_ENABLED=false  \
+ACTIONS_VERSION=${DATAHUB_ACTIONS_VERSION}  \
+datahub docker quickstart

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Runs a basic e2e test. It is not meant to be fully comprehensive,
+# but rather should catch obvious bugs before they make it into prod.
+#
+# Script assumptions:
+#   - The gradle build has already been run.
+#   - Python 3.6+ is installed and in the PATH.
+
+# Log the locally loaded images
+# docker images | grep "datahub-"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
+
+if [ "${RUN_QUICKSTART:-true}" == "true" ]; then
+    source ./run-quickstart.sh
+else
+  mkdir -p ~/.datahub/plugins/frontend/auth/
+  echo "test_user:test_pass" >> ~/.datahub/plugins/frontend/auth/user.props
+  echo "admin:mypass" > ~/.datahub/plugins/frontend/auth/user.props
+
+  python3 -m venv venv
+  source venv/bin/activate
+  python -m pip install --upgrade pip uv>=0.1.10 wheel setuptools
+  uv pip install -r requirements.txt
+fi
+
+# set environment variables for the test
+export DATAHUB_GMS_URL=http://localhost:8080
+
+# source ./set-test-env-vars.sh
+pytest -rP --durations=20 -vv --continue-on-collection-errors --junit-xml=junit.smoke.xml

--- a/smoke-test/tests/actions/doc_propagation/resources/datasets.yaml
+++ b/smoke-test/tests/actions/doc_propagation/resources/datasets.yaml
@@ -1,0 +1,20 @@
+# This file is used to define a dataset and provide metadata for it
+- urn: urn:li:dataset:(urn:li:dataPlatform:hive,user.clicks,PROD)
+  subtype: Table
+  schema:
+    file: tests/actions/doc_propagation/resources/user_clicks.avsc
+
+- urn: urn:li:dataset:(urn:li:dataPlatform:events,ClickEvent,PROD)
+  subtype: Topic
+  description: |
+    This is a sample event that is generated when a user clicks on a link.
+    Do not use this event for any purpose other than testing.
+  schema:
+    file: tests/actions/doc_propagation/resources/user_clicks.avsc
+    fields:
+      - id: ip
+        description: 'the ip address of the user'
+      - id: user_id
+        description: 'the user id'
+  downstreams:
+    - urn:li:dataset:(urn:li:dataPlatform:hive,user.clicks,PROD)

--- a/smoke-test/tests/actions/doc_propagation/resources/user_clicks.avsc
+++ b/smoke-test/tests/actions/doc_propagation/resources/user_clicks.avsc
@@ -1,0 +1,47 @@
+{
+    "namespace": "org.acryl",
+    "type": "record",
+    "name": "ClickEvent",
+    "fields": [
+        {
+            "name": "ip",
+            "type": "string"
+        },
+        {
+            "name": "url",
+            "type": "string"
+        },
+        {
+            "name": "time",
+            "type": "long"
+        },
+        {
+            "name": "referer",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        {
+            "name": "user_agent",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        {
+            "name": "user_id",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        {
+            "name": "session_id",
+            "type": [
+                "string",
+                "null"
+            ]
+        }
+    ]
+}

--- a/smoke-test/tests/actions/doc_propagation/test_propagation.py
+++ b/smoke-test/tests/actions/doc_propagation/test_propagation.py
@@ -1,0 +1,187 @@
+import logging
+import os
+import tempfile
+from pathlib import Path
+from random import randint
+from typing import Any, List
+
+import datahub.metadata.schema_classes as models
+import pytest
+from datahub.emitter.mce_builder import make_dataset_urn, make_schema_field_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
+from datahub.ingestion.api.sink import NoopWriteCallback
+from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.ingestion.sink.file import FileSink, FileSinkConfig
+from datahub.utilities.urns.urn import Urn
+
+from tests.utils import (
+    delete_urns_from_file,
+    get_gms_url,
+    ingest_file_via_rest,
+    wait_for_writes_to_sync,
+)
+
+logger = logging.getLogger(__name__)
+
+
+start_index = randint(10, 10000)
+dataset_urns = [
+    make_dataset_urn("snowflake", f"table_foo_{i}")
+    for i in range(start_index, start_index + 10)
+]
+
+
+class FileEmitter:
+    def __init__(self, filename: str) -> None:
+        self.sink: FileSink = FileSink(
+            ctx=PipelineContext(run_id="create_test_data"),
+            config=FileSinkConfig(filename=filename),
+        )
+
+    def emit(self, event):
+        self.sink.write_record_async(
+            record_envelope=RecordEnvelope(record=event, metadata={}),
+            write_callback=NoopWriteCallback(),
+        )
+
+    def close(self):
+        self.sink.close()
+
+
+def sanitize_field(field: models.SchemaFieldClass) -> models.SchemaFieldClass:
+    if field.fieldPath.startswith("[version=2.0]"):
+        field.fieldPath = field.fieldPath.split(".")[-1]
+
+    return field
+
+
+def sanitize(event: Any) -> Any:
+    if isinstance(event, MetadataChangeProposalWrapper):
+        if event.aspectName == "schemaMetadata":
+            assert isinstance(event.aspect, models.SchemaMetadataClass)
+            schema_metadata: models.SchemaMetadataClass = event.aspect
+            schema_metadata.fields = [
+                sanitize_field(field) for field in schema_metadata.fields
+            ]
+
+    return event
+
+
+def create_test_data(filename: str, test_resources_dir: str) -> List[str]:
+    def get_urns_from_mcp(mcp: MetadataChangeProposalWrapper) -> List[str]:
+        assert mcp.entityUrn
+        urns = [mcp.entityUrn]
+        if mcp.aspectName == "schemaMetadata":
+            dataset_urn = mcp.entityUrn
+            assert isinstance(mcp.aspect, models.SchemaMetadataClass)
+            schema_metadata: models.SchemaMetadataClass = mcp.aspect
+            for field in schema_metadata.fields:
+                field_urn = make_schema_field_urn(dataset_urn, field.fieldPath)
+                urns.append(field_urn)
+        return urns
+
+    from datahub.api.entities.dataset.dataset import Dataset
+
+    mcps = []
+    all_urns = []
+    for dataset in Dataset.from_yaml(file=f"{test_resources_dir}/datasets.yaml"):
+        mcps.extend([sanitize(event) for event in dataset.generate_mcp()])
+
+    file_emitter = FileEmitter(filename)
+    for mcp in mcps:
+        all_urns.extend(get_urns_from_mcp(mcp))
+        file_emitter.emit(mcp)
+
+    file_emitter.close()
+    return list(set(all_urns))
+
+
+@pytest.fixture(scope="module", autouse=False)
+def root_dir(pytestconfig):
+    return pytestconfig.rootdir
+
+
+@pytest.fixture(scope="module", autouse=False)
+def test_resources_dir(root_dir):
+    return Path(root_dir) / "tests" / "actions" / "doc_propagation" / "resources"
+
+
+@pytest.fixture(scope="module", autouse=False)
+def ingest_cleanup_data(request, test_resources_dir, graph):
+    new_file, filename = tempfile.mkstemp(suffix=".json")
+    try:
+        all_urns = create_test_data(filename, test_resources_dir)
+        print("ingesting datasets test data")
+        ingest_file_via_rest(filename)
+        yield
+        print("removing test data")
+        delete_urns_from_file(filename)
+        for urn in all_urns:
+            graph.delete_entity(urn, hard=True)
+        wait_for_writes_to_sync()
+    finally:
+        os.remove(filename)
+
+
+@pytest.fixture(scope="module", autouse=False)
+def graph():
+    graph: DataHubGraph = DataHubGraph(config=DatahubClientConfig(server=get_gms_url()))
+    yield graph
+
+
+@pytest.mark.dependency()
+def test_healthchecks(wait_for_healthchecks):
+    # Call to wait_for_healthchecks fixture will do the actual functionality.
+    pass
+
+
+def add_col_col_lineage(graph):
+    field_path = "ip"
+
+    downstream_field = f"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,user.clicks,PROD),{field_path})"
+    upstream_field = f"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:events,ClickEvent,PROD),{field_path})"
+    dataset1 = "urn:li:dataset:(urn:li:dataPlatform:hive,user.clicks,PROD)"
+    upstreams = graph.get_aspect(dataset1, models.UpstreamLineageClass)
+    upstreams.fineGrainedLineages = [
+        models.FineGrainedLineageClass(
+            upstreamType=models.FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+            downstreamType=models.FineGrainedLineageDownstreamTypeClass.FIELD,
+            upstreams=[upstream_field],
+            downstreams=[downstream_field],
+        )
+    ]
+    graph.emit(MetadataChangeProposalWrapper(entityUrn=dataset1, aspect=upstreams))
+    wait_for_writes_to_sync()
+    return downstream_field, upstream_field
+
+
+def add_field_description(f1, description, graph):
+    import datahub.metadata.schema_classes as models
+
+    urn = Urn.from_string(f1)
+    dataset_urn = urn.entity_ids[0]
+    schema_metadata = graph.get_aspect(dataset_urn, models.SchemaMetadataClass)
+    field = next(f for f in schema_metadata.fields if f.fieldPath == urn.entity_ids[1])
+    field.description = description
+    graph.emit(
+        MetadataChangeProposalWrapper(entityUrn=dataset_urn, aspect=schema_metadata)
+    )
+    wait_for_writes_to_sync()
+
+
+def check_propagated_description(downstream_field, description, graph):
+    import datahub.metadata.schema_classes as models
+
+    documentation = graph.get_aspect(downstream_field, models.DocumentationClass)
+    assert any(doc.documentation == description for doc in documentation.documentations)
+
+
+@pytest.mark.dependency(depends=["test_healthchecks"])
+def test_col_col_propagation(ingest_cleanup_data, graph):
+    downstream_field, upstream_field = add_col_col_lineage(graph)
+    add_field_description(upstream_field, "This is the new description", graph)
+    check_propagated_description(downstream_field, "This is the new description", graph)
+    # Call to wait_for_healthchecks fixture will do the actual functionality.
+    print("test_col_col_propagation")
+    pass

--- a/smoke-test/tests/actions/doc_propagation/test_propagation.py
+++ b/smoke-test/tests/actions/doc_propagation/test_propagation.py
@@ -7,6 +7,7 @@ from typing import Any, List
 
 import datahub.metadata.schema_classes as models
 import pytest
+from datahub.api.entities.dataset.dataset import Dataset
 from datahub.emitter.mce_builder import make_dataset_urn, make_schema_field_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
@@ -80,8 +81,6 @@ def create_test_data(filename: str, test_resources_dir: str) -> List[str]:
                 field_urn = make_schema_field_urn(dataset_urn, field.fieldPath)
                 urns.append(field_urn)
         return urns
-
-    from datahub.api.entities.dataset.dataset import Dataset
 
     mcps = []
     all_urns = []
@@ -157,8 +156,6 @@ def add_col_col_lineage(graph):
 
 
 def add_field_description(f1, description, graph):
-    import datahub.metadata.schema_classes as models
-
     urn = Urn.from_string(f1)
     dataset_urn = urn.entity_ids[0]
     schema_metadata = graph.get_aspect(dataset_urn, models.SchemaMetadataClass)
@@ -171,8 +168,6 @@ def add_field_description(f1, description, graph):
 
 
 def check_propagated_description(downstream_field, description, graph):
-    import datahub.metadata.schema_classes as models
-
     documentation = graph.get_aspect(downstream_field, models.DocumentationClass)
     assert any(doc.documentation == description for doc in documentation.documentations)
 

--- a/smoke-test/tests/conftest.py
+++ b/smoke-test/tests/conftest.py
@@ -1,3 +1,5 @@
+# Copied largely without modification from datahub-project/datahub/smoke-test/tests
+
 import os
 
 import pytest

--- a/smoke-test/tests/conftest.py
+++ b/smoke-test/tests/conftest.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+
+from tests.utils import get_frontend_session, wait_for_healthcheck_util
+
+# Disable telemetry
+os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
+
+
+@pytest.fixture(scope="session")
+def wait_for_healthchecks():
+    wait_for_healthcheck_util()
+    yield
+
+
+@pytest.fixture(scope="session")
+def frontend_session(wait_for_healthchecks):
+    yield get_frontend_session()
+
+
+# TODO: Determine whether we need this or not.
+@pytest.mark.dependency()
+def test_healthchecks(wait_for_healthchecks):
+    # Call to wait_for_healthchecks fixture will do the actual functionality.
+    pass

--- a/smoke-test/tests/consistency_utils.py
+++ b/smoke-test/tests/consistency_utils.py
@@ -1,0 +1,55 @@
+import logging
+import os
+import subprocess
+import time
+
+_ELASTIC_BUFFER_WRITES_TIME_IN_SEC: int = 1
+USE_STATIC_SLEEP: bool = bool(os.getenv("USE_STATIC_SLEEP", False))
+ELASTICSEARCH_REFRESH_INTERVAL_SECONDS: int = int(
+    os.getenv("ELASTICSEARCH_REFRESH_INTERVAL_SECONDS", 5)
+)
+KAFKA_BROKER_CONTAINER: str = str(
+    os.getenv("KAFKA_BROKER_CONTAINER", "datahub-broker-1")
+)
+KAFKA_BOOTSTRAP_SERVER: str = str(os.getenv("KAFKA_BOOTSTRAP_SERVER", "broker:29092"))
+
+logger = logging.getLogger(__name__)
+
+
+def wait_for_writes_to_sync(max_timeout_in_sec: int = 120) -> None:
+    if USE_STATIC_SLEEP:
+        time.sleep(ELASTICSEARCH_REFRESH_INTERVAL_SECONDS)
+        return
+    start_time = time.time()
+    # get offsets
+    lag_zero = False
+    while not lag_zero and (time.time() - start_time) < max_timeout_in_sec:
+        time.sleep(1)  # micro-sleep
+
+        cmd = (
+            f"docker exec {KAFKA_BROKER_CONTAINER} /bin/kafka-consumer-groups --bootstrap-server {KAFKA_BOOTSTRAP_SERVER} --group generic-mae-consumer-job-client --describe | grep -v LAG "
+            + "| awk '{print $6}'"
+        )
+        try:
+            completed_process = subprocess.run(
+                cmd,
+                capture_output=True,
+                shell=True,
+                text=True,
+            )
+            result = str(completed_process.stdout)
+            lines = result.splitlines()
+            lag_values = [int(line) for line in lines if line != ""]
+            maximum_lag = max(lag_values)
+            if maximum_lag == 0:
+                lag_zero = True
+        except ValueError:
+            logger.warning(f"Error reading kafka lag using command: {cmd}")
+
+    if not lag_zero:
+        logger.warning(
+            f"Exiting early from waiting for elastic to catch up due to a timeout. Current lag is {lag_values}"
+        )
+    else:
+        # we want to sleep for an additional period of time for Elastic writes buffer to clear
+        time.sleep(_ELASTIC_BUFFER_WRITES_TIME_IN_SEC)

--- a/smoke-test/tests/consistency_utils.py
+++ b/smoke-test/tests/consistency_utils.py
@@ -1,3 +1,4 @@
+# Copied largely without modification from datahub-project/datahub/smoke-test/tests
 import logging
 import os
 import subprocess

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -1,0 +1,223 @@
+import functools
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Tuple
+
+from datahub.cli import cli_utils, env_utils
+from datahub.ingestion.graph.client import DataHubGraph, get_default_graph
+from datahub.ingestion.run.pipeline import Pipeline
+from joblib import Parallel, delayed
+
+import requests_wrapper as requests
+from tests.consistency_utils import wait_for_writes_to_sync
+
+TIME: int = 1581407189000
+logger = logging.getLogger(__name__)
+
+
+def get_frontend_session():
+    username, password = get_admin_credentials()
+    return login_as(username, password)
+
+
+def login_as(username: str, password: str):
+    return cli_utils.get_frontend_session_login_as(
+        username=username, password=password, frontend_url=get_frontend_url()
+    )
+
+
+def get_admin_username() -> str:
+    return get_admin_credentials()[0]
+
+
+def get_admin_credentials():
+    return (
+        os.getenv("ADMIN_USERNAME", "datahub"),
+        os.getenv("ADMIN_PASSWORD", "datahub"),
+    )
+
+
+def get_root_urn():
+    return "urn:li:corpuser:datahub"
+
+
+def get_gms_url():
+    return os.getenv("DATAHUB_GMS_URL") or "http://localhost:8080"
+
+
+def get_frontend_url():
+    return os.getenv("DATAHUB_FRONTEND_URL") or "http://localhost:9002"
+
+
+def get_kafka_broker_url():
+    return os.getenv("DATAHUB_KAFKA_URL") or "localhost:9092"
+
+
+def get_kafka_schema_registry():
+    #  internal registry "http://localhost:8080/schema-registry/api/"
+    return os.getenv("DATAHUB_KAFKA_SCHEMA_REGISTRY_URL") or "http://localhost:8081"
+
+
+def get_mysql_url():
+    return os.getenv("DATAHUB_MYSQL_URL") or "localhost:3306"
+
+
+def get_mysql_username():
+    return os.getenv("DATAHUB_MYSQL_USERNAME") or "datahub"
+
+
+def get_mysql_password():
+    return os.getenv("DATAHUB_MYSQL_PASSWORD") or "datahub"
+
+
+def get_sleep_info() -> Tuple[int, int]:
+    return (
+        int(os.getenv("DATAHUB_TEST_SLEEP_BETWEEN", 20)),
+        int(os.getenv("DATAHUB_TEST_SLEEP_TIMES", 3)),
+    )
+
+
+def is_k8s_enabled():
+    return os.getenv("K8S_CLUSTER_ENABLED", "false").lower() in ["true", "yes"]
+
+
+def wait_for_healthcheck_util():
+    assert not check_endpoint(f"{get_frontend_url()}/admin")
+    assert not check_endpoint(f"{get_gms_url()}/health")
+
+
+def check_endpoint(url):
+    try:
+        get = requests.get(url)
+        if get.status_code == 200:
+            return
+        else:
+            return f"{url}: is Not reachable, status_code: {get.status_code}"
+    except requests.exceptions.RequestException as e:
+        raise SystemExit(f"{url}: is Not reachable \nErr: {e}")
+
+
+def ingest_file_via_rest(filename: str) -> Pipeline:
+    pipeline = Pipeline.create(
+        {
+            "source": {
+                "type": "file",
+                "config": {"filename": filename},
+            },
+            "sink": {
+                "type": "datahub-rest",
+                "config": {"server": get_gms_url()},
+            },
+        }
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+    wait_for_writes_to_sync()
+    return pipeline
+
+
+@functools.lru_cache(maxsize=1)
+def get_datahub_graph() -> DataHubGraph:
+    return get_default_graph()
+
+
+def delete_urn(urn: str) -> None:
+    get_datahub_graph().hard_delete_entity(urn)
+
+
+def delete_urns(urns: List[str]) -> None:
+    for urn in urns:
+        delete_urn(urn)
+
+
+def delete_urns_from_file(filename: str, shared_data: bool = False) -> None:
+    if not env_utils.get_boolean_env_variable("CLEANUP_DATA", True):
+        print("Not cleaning data to save time")
+        return
+    session = requests.Session()
+    session.headers.update(
+        {
+            "X-RestLi-Protocol-Version": "2.0.0",
+            "Content-Type": "application/json",
+        }
+    )
+
+    def delete(entry):
+        is_mcp = "entityUrn" in entry
+        urn = None
+        # Kill Snapshot
+        if is_mcp:
+            urn = entry["entityUrn"]
+        else:
+            snapshot_union = entry["proposedSnapshot"]
+            snapshot = list(snapshot_union.values())[0]
+            urn = snapshot["urn"]
+        delete_urn(urn)
+
+    with open(filename) as f:
+        d = json.load(f)
+        Parallel(n_jobs=10)(delayed(delete)(entry) for entry in d)
+
+    wait_for_writes_to_sync()
+
+
+# Fixed now value
+NOW: datetime = datetime.now()
+
+
+def get_timestampmillis_at_start_of_day(relative_day_num: int) -> int:
+    """
+    Returns the time in milliseconds from epoch at the start of the day
+    corresponding to `now + relative_day_num`
+
+    """
+    time: datetime = NOW + timedelta(days=float(relative_day_num))
+    time = datetime(
+        year=time.year,
+        month=time.month,
+        day=time.day,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0,
+    )
+    return int(time.timestamp() * 1000)
+
+
+def get_strftime_from_timestamp_millis(ts_millis: int) -> str:
+    return datetime.fromtimestamp(ts_millis / 1000, tz=timezone.utc).isoformat()
+
+
+def create_datahub_step_state_aspect(
+    username: str, onboarding_id: str
+) -> Dict[str, Any]:
+    entity_urn = f"urn:li:dataHubStepState:urn:li:corpuser:{username}-{onboarding_id}"
+    print(f"Creating dataHubStepState aspect for {entity_urn}")
+    return {
+        "auditHeader": None,
+        "entityType": "dataHubStepState",
+        "entityUrn": entity_urn,
+        "changeType": "UPSERT",
+        "aspectName": "dataHubStepStateProperties",
+        "aspect": {
+            "value": f'{{"properties":{{}},"lastModified":{{"actor":"urn:li:corpuser:{username}","time":{TIME}}}}}',
+            "contentType": "application/json",
+        },
+        "systemMetadata": None,
+    }
+
+
+def create_datahub_step_state_aspects(
+    username: str, onboarding_ids: List[str], onboarding_filename: str
+) -> None:
+    """
+    For a specific user, creates dataHubStepState aspects for each onboarding id in the list
+    """
+    aspects_dict: List[Dict[str, Any]] = [
+        create_datahub_step_state_aspect(username, onboarding_id)
+        for onboarding_id in onboarding_ids
+    ]
+    with open(onboarding_filename, "w") as f:
+        json.dump(aspects_dict, f, indent=2)

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -1,3 +1,4 @@
+# Copied largely without modification from datahub-project/datahub/smoke-test/tests
 import functools
 import json
 import logging


### PR DESCRIPTION
This PR introduces a new DocPropagationAction for column-level documentation propagation. 

Key features include:

1. Automated propagation of documentation changes to downstream and sibling schema fields
2. Configuration options to enable/disable propagation at global and column levels
3. Support for ADD, MODIFY, and REMOVE operations on documentation
4. Integration with DataHub's event system, processing EntityChangeEvents and MetadataChangeLogs
5. Ability to fetch and apply global settings from DataHub
6. Detailed logging and statistics tracking for monitoring and debugging

As seen in DataHub townhall - https://youtu.be/hdqgjxiW-zI?t=2051