### PR TITLE
Add explicit dependency on confluent-kafka[schemaregistry]

### DIFF
--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -67,7 +67,9 @@ aws_common = {
 # Note: for all of these, framework_common will be added.
 plugins: Dict[str, Set[str]] = {
     # Source Plugins
-    "kafka": set(),  # included by default
+    "kafka": {
+        "confluent-kafka[schemaregistry]",
+    },
     # Action Plugins
     "executor": {
         "acryl-executor==0.1.2",


### PR DESCRIPTION
kafka plugin [depends](https://github.com/acryldata/datahub-actions/blob/main/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py#L22) on schemaregistry from confluent-kafka package, so its dependencies have to be installed as well