### PR TITLE
fix: Remove uv cache from docker image

### DIFF
--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -149,7 +149,10 @@ jobs:
             "APP_ENV=prod-slim"
       - name: Save Docker image
         if: needs.setup.outputs.publish != 'true'
-        run: docker image save -o image.tar ${{ steps.docker_meta_slim.outputs.tags }}
+        # Replace new line characters with spaces in
+        # steps.docker_meta_slim.outputs.tags as the new lines splits the
+        # command into two otherwise.
+        run: docker image save -o image.tar $(echo "${{ steps.docker_meta_slim.outputs.tags }}" | tr '\n' ' ')
       - name: Upload artifact
         if: needs.setup.outputs.publish != 'true'
         uses: actions/upload-artifact@v4

--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -46,7 +46,8 @@ RUN --mount=type=cache,target=/datahub-ingestion/.cache/uv,uid=1000,gid=1000 \
 
 FROM base AS prod-install
 
-RUN UV_LINK_MODE=copy uv pip install -e ".[all]"
+RUN --mount=type=cache,target=/datahub-ingestion/.cache/uv,uid=1000,gid=1000 \
+    UV_LINK_MODE=copy uv pip install -e ".[all]"
 
 FROM ${APP_ENV}-install AS final
 WORKDIR /datahub-ingestion


### PR DESCRIPTION
This makes the docker image about 25% smaller (~800MB).

Before the change the image is about 3.08GB, reported by `docker images` and with the change is is about  2.27GB.

Fixes #157