### PR TITLE
fix(propagation): Don't fail in propagation if origin is missing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Gradle build (and test)
         run: |
           ./gradlew build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test Results (build)
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -214,6 +214,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         env:
           TRIVY_OFFLINE_SCAN: true
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
         with:
           image-ref: acryldata/datahub-actions-slim:${{ needs.setup.outputs.unique_tag }}
           format: "template"

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -201,7 +201,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Download artifact (if not publishing)
         if: needs.setup.outputs.publish != 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker-image
       - name: Load Docker image (if not publishing)
@@ -252,7 +252,7 @@ jobs:
           cache: "pip"
       - name: Download artifact (if not publishing)
         if: needs.setup.outputs.publish != 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker-image
       - name: Load Docker image (if not publishing)

--- a/.github/workflows/datahub-actions-docker.yml
+++ b/.github/workflows/datahub-actions-docker.yml
@@ -152,7 +152,7 @@ jobs:
         run: docker image save -o image.tar ${{ steps.docker_meta_slim.outputs.tags }}
       - name: Upload artifact
         if: needs.setup.outputs.publish != 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-image
           path: image.tar

--- a/datahub-actions/src/datahub_actions/plugin/action/propagation/docs/propagation_action.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/propagation/docs/propagation_action.py
@@ -305,7 +305,11 @@ class DocPropagationAction(Action):
                 propagation_relationships = self.get_propagation_relationships(
                     entity_type="schemaField", source_details=source_details_parsed
                 )
-                origin_entity = source_details_parsed.origin
+                origin_entity = (
+                    source_details_parsed.origin
+                    if source_details_parsed.origin
+                    else entity_urn
+                )
                 if old_docs is None or not old_docs.documentations:
                     return DocPropagationDirective(
                         propagate=True,

--- a/smoke-test/tests/actions/doc_propagation/test_propagation.py
+++ b/smoke-test/tests/actions/doc_propagation/test_propagation.py
@@ -107,7 +107,7 @@ def action_env_vars(pytestconfig) -> ActionTestEnv:
                 key, value = line.split("=", 1)
                 env_vars[key] = value
 
-    return ActionTestEnv.parse_obj(**env_vars)
+    return ActionTestEnv.parse_obj(env_vars)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
- When the AI description action sets the Attribution aspect, it doesn’t set the Attribution details that the propagation action expects to have in MCL. This causes the origin to be null, which breaks Doc propagation since it requires a non-empty origin.. This leads to null origin, which in the Doc propagation code can't be empty and fails. 
In this fix, I make sure it is set if it is empty to the entity's urn; in this case, this is where the change request comes from.
- lint fixes