### PR TITLE
fix(dockerfile): clean apt cache folders

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -29,7 +29,8 @@ RUN chmod a+x /start_datahub_actions.sh && \
     apt-get update && \
     apt-get install -y -qq default-jre && \
     apt-get clean && \
-    rm -rf /var/lib/{apt,dpkg,cache,log}/
+    rm -rf /var/lib/apt && \
+    rm -rf /var/lib/cache
 
 COPY --chown=datahub:datahub datahub-actions /actions-src
 # Add other default configurations into this!


### PR DESCRIPTION
## Description

When building a Dockerfile we aren't running bash, so it doesn't do brace expansion, so this kind of things don't work:

`rm -rf /var/lib/{apt,dpkg,cache,log}/`

I've substituted it by the individual commands except for `dpkg`, as it would break the use of `apt` in next executions, and `log`, that seems to be empty.
