### PR TITLE
feat(changeSync): remap restate mcps to upsert

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Set, Union, cast
 
 from datahub.emitter.rest_emitter import DatahubRestEmitter
 from datahub.metadata.schema_classes import (
+    ChangeTypeClass,
     MetadataChangeLogClass,
     MetadataChangeProposalClass,
 )
@@ -132,7 +133,7 @@ class MetadataChangeSyncAction(Action):
                 changeType = ChangeTypeClass.UPSERT
             mcp = MetadataChangeProposalClass(
                 entityType=orig_event.get("entityType"),
-                changeType=orig_event.get("changeType"),
+                changeType=change_type,
                 entityUrn=orig_event.get("entityUrn"),
                 entityKeyAspect=orig_event.get("entityKeyAspect"),
                 aspectName=orig_event.get("aspectName"),

--- a/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
@@ -128,6 +128,8 @@ class MetadataChangeSyncAction(Action):
         self, orig_event: MetadataChangeLogClass
     ) -> Union[MetadataChangeProposalClass, None]:
         try:
+            if orig_event.changeType is ChangeTypeClass.RESTATE:
+                changeType = ChangeTypeClass.UPSERT
             mcp = MetadataChangeProposalClass(
                 entityType=orig_event.get("entityType"),
                 changeType=orig_event.get("changeType"),

--- a/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
@@ -129,7 +129,7 @@ class MetadataChangeSyncAction(Action):
         self, orig_event: MetadataChangeLogClass
     ) -> Union[MetadataChangeProposalClass, None]:
         try:
-            if orig_event.changeType is ChangeTypeClass.RESTATE:
+            if orig_event.changeType == ChangeTypeClass.RESTATE or orig_event.changeType == "RESTATE":
                 changeType = ChangeTypeClass.UPSERT
             mcp = MetadataChangeProposalClass(
                 entityType=orig_event.get("entityType"),


### PR DESCRIPTION
RESTATE MCPs are not supported, this allows the sync action to refeed in RESTATEs for syncing status using restoreIndices